### PR TITLE
feat(upload): presigned 3단계 업로드 흐름으로 전환 (MEL-44)

### DIFF
--- a/frontend/src/api/posts.ts
+++ b/frontend/src/api/posts.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import axiosInstance from './axiosInstance';
 import type {
   PaginatedPosts,
@@ -14,6 +15,10 @@ import type {
   CommentResponse,
   Attachment,
   PostImage,
+  UploadInitRequest,
+  UploadInitResponse,
+  UploadConfirmRequest,
+  UploadConfirmResponse,
 } from '../types/post';
 
 export async function fetchPosts(params: {
@@ -151,3 +156,21 @@ export async function deletePostAttachment(postId: number, attachmentId: number)
 }
 
 // TODO: 백엔드에 이미지 DELETE 엔드포인트(/posts/{postId}/images/{imageId}) 추가 요청 후 구현 예정
+
+// Presigned Upload — 3단계 흐름 (init → S3 PUT → confirm)
+export async function initUpload(postId: number, req: UploadInitRequest): Promise<UploadInitResponse> {
+  const res = await axiosInstance.post(`/posts/${postId}/uploads/init`, req);
+  return res.data?.data ?? res.data;
+}
+
+// axiosInstance 대신 raw axios 사용 — presigned URL에 Authorization 헤더를 붙이면 S3 서명 불일치로 에러남
+export async function uploadToS3(uploadUrl: string, file: File, contentType: string): Promise<void> {
+  await axios.put(uploadUrl, file, {
+    headers: { 'Content-Type': contentType },
+  });
+}
+
+export async function confirmUpload(postId: number, req: UploadConfirmRequest): Promise<UploadConfirmResponse> {
+  const res = await axiosInstance.post(`/posts/${postId}/uploads/confirm`, req);
+  return res.data?.data ?? res.data;
+}

--- a/frontend/src/hooks/useFileAttachment.ts
+++ b/frontend/src/hooks/useFileAttachment.ts
@@ -1,18 +1,50 @@
 import { useEffect, useRef, useState } from 'react';
 
-export const IMAGE_MAX_SIZE = 5 * 1024 * 1024; // 5MB
-export const PDF_MAX_SIZE = 10 * 1024 * 1024; // 10MB
-export const MAX_FILE_COUNT = 10;
+export const IMAGE_MAX_SIZE = 10 * 1024 * 1024; // 10MB
+export const ATTACHMENT_MAX_SIZE = 50 * 1024 * 1024; // 50MB
+export const MAX_IMAGE_COUNT = 10;
+export const MAX_ATTACHMENT_COUNT = 5;
 export const IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 export const IMAGE_ACCEPT = IMAGE_TYPES.join(',');
-export const FILE_ACCEPT = '.pdf,application/pdf';
+export const FILE_ACCEPT = '.pdf,.hwp,.docx,.xlsx';
+
+const ATTACHMENT_MIME_TYPES = [
+  'application/pdf',
+  'application/x-hwp',
+  'application/haansofthwp',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+];
+const ATTACHMENT_EXTENSIONS = ['.pdf', '.hwp', '.docx', '.xlsx'];
 
 export interface PendingFile {
   file: File;
   previewUrl: string | null;
+  kind: 'IMAGE' | 'ATTACHMENT';
 }
 
-export function useFileAttachment(existingCount = 0) {
+export function isImageFile(file: File): boolean {
+  return IMAGE_TYPES.includes(file.type);
+}
+
+export function isAttachmentFile(file: File): boolean {
+  const name = file.name.toLowerCase();
+  if (ATTACHMENT_EXTENSIONS.some((ext) => name.endsWith(ext))) return true;
+  return ATTACHMENT_MIME_TYPES.includes(file.type);
+}
+
+// HWP·docx·xlsx는 브라우저마다 MIME이 달라 확장자 기준으로 정규화
+export function resolveUploadContentType(file: File): string {
+  const name = file.name.toLowerCase();
+  if (name.endsWith('.hwp')) return 'application/x-hwp';
+  if (name.endsWith('.docx'))
+    return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+  if (name.endsWith('.xlsx'))
+    return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+  return file.type;
+}
+
+export function useFileAttachment(existingImageCount = 0, existingAttachmentCount = 0) {
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
   const [fileError, setFileError] = useState<string | null>(null);
   const imageInputRef = useRef<HTMLInputElement>(null);
@@ -27,30 +59,52 @@ export function useFileAttachment(existingCount = 0) {
 
   function addFiles(files: FileList | null) {
     if (!files) return;
-    if (existingCount + pendingFiles.length + files.length > MAX_FILE_COUNT) {
-      setFileError(`첨부파일은 최대 ${MAX_FILE_COUNT}개까지 가능합니다.`);
-      return;
-    }
     const newFiles: PendingFile[] = [];
+
     for (const file of Array.from(files)) {
-      const isImage = IMAGE_TYPES.includes(file.type);
-      const isPdf = file.type === 'application/pdf' || /\.pdf$/i.test(file.name);
-      if (!isImage && !isPdf) {
-        setFileError(`${file.name}: 이미지(jpg, png, webp) 또는 PDF 파일만 첨부할 수 있습니다.`);
+      const isImage = isImageFile(file);
+      const isAttachment = isAttachmentFile(file);
+
+      if (!isImage && !isAttachment) {
+        setFileError(
+          `${file.name}: 이미지(jpg·png·webp) 또는 문서(PDF·HWP·docx·xlsx) 파일만 첨부할 수 있습니다.`,
+        );
         continue;
       }
-      if (isImage && file.size > IMAGE_MAX_SIZE) {
-        setFileError(`${file.name}: 이미지는 5MB 이하만 첨부할 수 있습니다.`);
-        continue;
+
+      if (isImage) {
+        const pendingImageCount =
+          pendingFiles.filter((f) => f.kind === 'IMAGE').length +
+          newFiles.filter((f) => f.kind === 'IMAGE').length;
+        if (existingImageCount + pendingImageCount >= MAX_IMAGE_COUNT) {
+          setFileError(`이미지는 최대 ${MAX_IMAGE_COUNT}장까지 첨부할 수 있습니다.`);
+          continue;
+        }
+        if (file.size > IMAGE_MAX_SIZE) {
+          setFileError(`${file.name}: 이미지는 10MB 이하만 첨부할 수 있습니다.`);
+          continue;
+        }
       }
-      if (isPdf && file.size > PDF_MAX_SIZE) {
-        setFileError(`${file.name}: PDF는 10MB 이하만 첨부할 수 있습니다.`);
-        continue;
+
+      if (isAttachment) {
+        const pendingAttachmentCount =
+          pendingFiles.filter((f) => f.kind === 'ATTACHMENT').length +
+          newFiles.filter((f) => f.kind === 'ATTACHMENT').length;
+        if (existingAttachmentCount + pendingAttachmentCount >= MAX_ATTACHMENT_COUNT) {
+          setFileError(`첨부파일은 최대 ${MAX_ATTACHMENT_COUNT}개까지 가능합니다.`);
+          continue;
+        }
+        if (file.size > ATTACHMENT_MAX_SIZE) {
+          setFileError(`${file.name}: 첨부파일은 50MB 이하만 가능합니다.`);
+          continue;
+        }
       }
+
       const previewUrl = isImage ? URL.createObjectURL(file) : null;
       if (previewUrl) pendingUrlsRef.current.push(previewUrl);
-      newFiles.push({ file, previewUrl });
+      newFiles.push({ file, previewUrl, kind: isImage ? 'IMAGE' : 'ATTACHMENT' });
     }
+
     setPendingFiles((prev) => [...prev, ...newFiles]);
   }
 
@@ -78,8 +132,4 @@ export function useFileAttachment(existingCount = 0) {
     removeFile,
     clearFileError,
   };
-}
-
-export function isImageFile(file: File): boolean {
-  return IMAGE_TYPES.includes(file.type);
 }

--- a/frontend/src/pages/post/PostCreatePage.tsx
+++ b/frontend/src/pages/post/PostCreatePage.tsx
@@ -3,12 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Image, Lock, LockOpen, Paperclip } from 'lucide-react';
 import SimpleTextEditor from '../../components/post/SimpleTextEditor';
 import FilePreviewGrid from '../../components/post/FilePreviewGrid';
-import { createPost, uploadPostPdf, uploadPostImage } from '../../api/posts';
+import { createPost, initUpload, uploadToS3, confirmUpload } from '../../api/posts';
 import {
   useFileAttachment,
   IMAGE_ACCEPT,
   FILE_ACCEPT,
-  isImageFile,
+  resolveUploadContentType,
 } from '../../hooks/useFileAttachment';
 import { useAuthStore } from '../../stores/useAuthStore';
 import type { TherapyArea } from '../../types/post';
@@ -71,17 +71,27 @@ export default function PostCreatePage() {
       });
       createdPostId = post.id;
 
-      // 첨부파일 순차 업로드
+      // 첨부파일 순차 업로드 (presigned 3단계: init → S3 PUT → confirm)
       let failedCount = 0;
       if (pendingFiles.length > 0) {
         setUploadProgress(`첨부파일 업로드 중... (0/${pendingFiles.length})`);
         for (let i = 0; i < pendingFiles.length; i++) {
           setUploadProgress(`첨부파일 업로드 중... (${i + 1}/${pendingFiles.length})`);
-          const file = pendingFiles[i].file;
-          // 이미지인지 판별해서 API 업로드
-          const upload = isImageFile(file) ? uploadPostImage : uploadPostPdf;
+          const pf = pendingFiles[i];
+          const contentType = resolveUploadContentType(pf.file);
           try {
-            await upload(post.id, file);
+            const { uploadUrl, storedKey } = await initUpload(post.id, {
+              kind: pf.kind,
+              originalFilename: pf.file.name,
+              contentType,
+              sizeBytes: pf.file.size,
+            });
+            await uploadToS3(uploadUrl, pf.file, contentType);
+            await confirmUpload(post.id, {
+              kind: pf.kind,
+              storedKey,
+              originalFilename: pf.file.name,
+            });
           } catch {
             failedCount++;
           }

--- a/frontend/src/pages/post/PostEditPage.tsx
+++ b/frontend/src/pages/post/PostEditPage.tsx
@@ -8,15 +8,16 @@ import {
   fetchPost,
   fetchPostImages,
   updatePost,
-  uploadPostPdf,
-  uploadPostImage,
+  initUpload,
+  uploadToS3,
+  confirmUpload,
   deletePostAttachment,
 } from '../../api/posts';
 import {
   useFileAttachment,
   IMAGE_ACCEPT,
   FILE_ACCEPT,
-  isImageFile,
+  resolveUploadContentType,
 } from '../../hooks/useFileAttachment';
 import { useAuthStore } from '../../stores/useAuthStore';
 import type { Attachment, PostImage, TherapyArea } from '../../types/post';
@@ -46,10 +47,6 @@ export default function PostEditPage() {
   const [removedAttachmentIds, setRemovedAttachmentIds] = useState<number[]>([]);
   const [uploadProgress, setUploadProgress] = useState<string | null>(null);
 
-  // 기존 이미지는 백엔드 DELETE 엔드포인트가 없어 삭제 불가 → 개수는 MAX 카운트에 포함
-  const remainingExisting =
-    existingAttachments.length - removedAttachmentIds.length + existingImages.length;
-
   const {
     pendingFiles,
     fileError,
@@ -58,7 +55,10 @@ export default function PostEditPage() {
     addFiles,
     removeFile: removePendingFile,
     clearFileError,
-  } = useFileAttachment(remainingExisting);
+  } = useFileAttachment(
+    existingImages.length,
+    existingAttachments.length - removedAttachmentIds.length,
+  );
 
   const hasChanges =
     content !== initialContent ||
@@ -142,9 +142,20 @@ export default function PostEditPage() {
         for (const pf of pendingFiles) {
           done++;
           setUploadProgress(`첨부파일 업로드 중... (${done}/${totalOps})`);
-          const upload = isImageFile(pf.file) ? uploadPostImage : uploadPostPdf;
+          const contentType = resolveUploadContentType(pf.file);
           try {
-            await upload(pid, pf.file);
+            const { uploadUrl, storedKey } = await initUpload(pid, {
+              kind: pf.kind,
+              originalFilename: pf.file.name,
+              contentType,
+              sizeBytes: pf.file.size,
+            });
+            await uploadToS3(uploadUrl, pf.file, contentType);
+            await confirmUpload(pid, {
+              kind: pf.kind,
+              storedKey,
+              originalFilename: pf.file.name,
+            });
           } catch {
             failedCount++;
           }

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -156,3 +156,31 @@ export interface CommentReaction {
   usefulCount: number;
   myReactionType: ReactionType | null;
 }
+
+// Presigned Upload (3단계 흐름)
+export type UploadKind = 'IMAGE' | 'ATTACHMENT' | 'VIDEO';
+
+export interface UploadInitRequest {
+  kind: UploadKind;
+  originalFilename: string;
+  contentType: string;
+  sizeBytes: number;
+}
+
+export interface UploadInitResponse {
+  uploadUrl: string;
+  storedKey: string;
+  expiresAt: string;
+}
+
+export interface UploadConfirmRequest {
+  kind: UploadKind;
+  storedKey: string;
+  originalFilename: string;
+}
+
+export interface UploadConfirmResponse {
+  kind: UploadKind;
+  image?: PostImage;
+  attachment?: Attachment;
+}


### PR DESCRIPTION
## 작업 배경

백엔드 PR #99에서 파일 업로드 방식이 multipart → presigned URL 3단계 흐름으로 변경되었습니다.
기존 엔드포인트(`POST /posts/{id}/images`, `/attachments`)는 `@Deprecated` 유지 중이나, 신규 흐름으로 전환합니다.

## 변경 내용

### 새 업로드 흐름 (3단계)
```
1. initUpload  — 백엔드에 파일 메타 신고 → uploadUrl / storedKey 수령
2. uploadToS3  — 수령한 presigned URL로 S3에 직접 PUT (raw axios, 토큰 헤더 미포함)
3. confirmUpload — 백엔드에 업로드 완료 신고
```

### 파일별 변경

| 파일 | 변경 요약 |
|---|---|
| `types/post.ts` | `UploadKind`, `UploadInitRequest/Response`, `UploadConfirmRequest/Response` 타입 추가 |
| `api/posts.ts` | `initUpload` / `uploadToS3`(raw axios) / `confirmUpload` 함수 추가 |
| `hooks/useFileAttachment.ts` | `PendingFile`에 `kind` 필드 추가, 허용 형식 확장(HWP·docx·xlsx), 용량 상향(이미지 10MB·첨부 50MB), 이미지/첨부 개수 한도 분리(10장/5개) |
| `PostCreatePage.tsx` | `handleSubmit` 업로드 로직 3단계로 교체 |
| `PostEditPage.tsx` | 동일, hook 시그니처를 `(imageCount, attachmentCount)`로 분리 |

## QA 체크리스트

- [ ] 이미지(jpg/png/webp) 업로드 정상 동작
- [ ] PDF 업로드 정상 동작
- [ ] HWP / docx / xlsx 신규 허용 확인
- [ ] 이미지 10MB 초과 시 에러 메시지
- [ ] 첨부 50MB 초과 시 에러 메시지
- [ ] 이미지 11장 선택 시 개수 초과 에러
- [ ] 첨부 6개 선택 시 개수 초과 에러
- [ ] 게시글 수정 화면에서 새 파일 추가 정상 동작

## 관련 이슈

- Jira: MEL-44
- Backend PR: #99