### PR TITLE
fix(comment): 한글 IME Enter 이중 발화로 인한 중복 POST 방어

### DIFF
--- a/frontend/src/components/post/CommentInput.tsx
+++ b/frontend/src/components/post/CommentInput.tsx
@@ -20,6 +20,10 @@ export default function CommentInput({
   const isMobile = navigator.maxTouchPoints > 0;
 
   function handleKeyDown(e:React.KeyboardEvent<HTMLTextAreaElement>){
+    // 한글 IME 합성 종료 시 Enter keydown이 2회 발화하는 React 이슈 방어.
+    // 가드 없으면 한글 댓글 작성 시 onSubmit이 20~30ms 간격으로 두 번 호출되어
+    // 백엔드에 중복 POST가 전송됨 (2026-05-11 백엔드 로그로 확인).
+    if (e.nativeEvent.isComposing) return;
     if(e.key === 'Enter' && !e.shiftKey && !isMobile){
       e.preventDefault()
       onSubmit()

--- a/frontend/src/hooks/useCommentSubmit.ts
+++ b/frontend/src/hooks/useCommentSubmit.ts
@@ -19,8 +19,11 @@ export function useCommentSubmit({
   const [submitting, setSubmitting] = useState(false);
 
   async function handleSubmit(content: string) {
+    // in-flight 가드: setSubmitting은 비동기 배치라 동기적 이중 호출(IME Enter 이중 발화,
+    // 더블탭 등)을 막지 못함. 함수 진입 시점 state로 직접 차단해야 두 번째 호출이 빠져나가지 않음.
+    if (submitting) return;
     const normalized = content.replace(/\n{3,}/g, '\n\n').trim();
-    if (!normalized.trim()) return;  
+    if (!normalized.trim()) return;
     setSubmitting(true);
     try {
       const newComment = await createComment(postId, {

--- a/frontend/src/pages/post/CommentWritePage.tsx
+++ b/frontend/src/pages/post/CommentWritePage.tsx
@@ -54,6 +54,9 @@ export default function CommentWritePage() {
   }, [postId]);
 
   async function handleSubmit() {
+    // in-flight 가드: useCommentSubmit과 동일 사유. setSubmitting 비동기 배치 race를
+    // 함수 진입 state 체크로 차단. (R-06로 useCommentSubmit 통합되면 자연 제거됨.)
+    if (submitting) return;
     if (!postId || !commentInput.trim()) return;
     setSubmitting(true);
     try {


### PR DESCRIPTION
## 배경

백엔드에서 동일 댓글의 `POST /api/v1/posts/{id}/comments`가 **20~30ms 간격으로 2회** 도착하는 현상 보고. 사람 더블탭 최저 간격(~80ms)으로는 만들 수 없는 시차라 이벤트 시스템의 자동 이중 발화로 원인 좁힘.

## 원인

React `onKeyDown`은 **한글 IME 합성 종료 시 Enter keydown을 2회 발화**한다 (`isComposing=true` 1회 + 실제 Enter 1회). `CommentInput.handleKeyDown`은 `isComposing`을 거르지 않아 `onSubmit()`이 두 번 호출됐고, 작성 hook(`useCommentSubmit`)·작성 페이지(`CommentWritePage`) 양쪽 모두 in-flight 가드가 없어 `setSubmitting`의 비동기 배치 race를 통과해 그대로 두 번 다 `createComment()` 실행 → 백엔드 POST 2건.

## 조치 (A + B 동시 적용)

| 종류 | 파일 | 내용 |
|---|---|---|
| **A. 가드** | `useCommentSubmit.ts` | `handleSubmit` 첫 줄 `if (submitting) return` |
| **A. 가드** | `CommentWritePage.tsx` | `handleSubmit` 첫 줄 `if (submitting) return` |
| **B. 근본** | `CommentInput.tsx` | `handleKeyDown` 진입 시 `e.nativeEvent.isComposing` 차단 |

- **A**는 IME 외 더블탭·재시도·이중 트리거 등 모든 경로의 두 번째 호출을 차단하는 방어막.
- **B**는 Enter 1회당 `onSubmit` 1회만 발화하도록 하는 근본 fix.

## 영향 범위

- 댓글/답글 작성 흐름만 변경
- UI/디자인 변화 없음 (디자이너 컨펌 불필요)
- 백엔드 API 변경 없음
- 타입체크 clean

## 검증 체크리스트

- [ ] PC + 한글 IME에서 댓글 입력 후 Enter — 댓글 1건만 생성되는지 (회귀 핵심)
- [ ] PC + 영문에서 Enter — 정상 1건 작성
- [ ] PC에서 댓글 작성 버튼 빠르게 더블클릭 — 1건만 작성
- [ ] 모바일 댓글 작성 페이지(`/posts/:id/comments/write`)에서 동일 패턴 — 1건만 작성
- [ ] Shift+Enter — 줄바꿈만 들어가고 submit 안 되는지
- [ ] 답글(parentCommentId 있는 경우) — 1건만 작성

## 백엔드 측 후속

프론트 패치 후에도 중복 POST가 계속 들어오면 백엔드 네트워크 레이어(프록시/재시도) 원인일 가능성이 높음. 머지 후 로그 모니터링 부탁드립니다.

## 관련

- 댓글 줄바꿈 정책 전환(2026-05-02) — textarea 전환 이후 잠재됐던 IME 이중 발화가 표면화된 것으로 추정
- R-06(useCommentSubmit 통합) 후속에서 `CommentWritePage`의 자체 `handleSubmit` 제거 예정