### PR TITLE
feat(feed): 피드 정렬 전환 UI 추가 (최신순/인기순)

### DIFF
--- a/frontend/src/hooks/useInfiniteFeed.ts
+++ b/frontend/src/hooks/useInfiniteFeed.ts
@@ -8,6 +8,7 @@ import type { PostSummary } from '../types/post';
 interface UseInfiniteFeedOptions {
   size?: number;
   enabled?: boolean; // 무한 스크롤 모드 ON/OFF (필터/팔로잉 탭에서는 false → 페이지네이션 모드)
+  sort?: 'LATEST' | 'POPULAR';
   initialSnapshot?: {
     // 뒤로가기 시 Zustand에 저장된 상태 복원용 (스크롤 위치 + 이미 로드된 아이템들)
     items: PostSummary[];
@@ -43,7 +44,7 @@ interface UseInfiniteFeedResult {
  * 항상 pages.length === pageParams.length 불변량을 지킵니다.
  */
 export function useInfiniteFeed(options: UseInfiniteFeedOptions = {}): UseInfiniteFeedResult {
-  const { size = 20, enabled = true, initialSnapshot } = options;
+  const { size = 20, enabled = true, sort = 'LATEST', initialSnapshot } = options;
 
   // onError 콜백을 ref로 보관합니다.
   // 이유: RQ v5에서 useQuery의 onError 옵션이 제거되었습니다.
@@ -73,7 +74,7 @@ export function useInfiniteFeed(options: UseInfiniteFeedOptions = {}): UseInfini
 
   const query = useInfiniteQuery({
     // 캐시 주소 — size가 바뀌면 별개 쿼리(별개 캐시 슬롯)가 됩니다.
-    queryKey: ['feed', { size }],
+    queryKey: ['feed', { size, sort }],
     // RQ가 호출하는 실제 페치 함수.
     // signal은 RQ가 자동으로 만들어 주는 AbortSignal입니다.
     // 컴포넌트 언마운트 / queryKey 변경 / queryClient.cancelQueries() 호출 시
@@ -81,6 +82,7 @@ export function useInfiniteFeed(options: UseInfiniteFeedOptions = {}): UseInfini
     queryFn: ({ pageParam, signal }) =>
       fetchFeed({
         size,
+        sort,
         ...(pageParam ? { cursor: pageParam } : {}),
         signal,
       }),

--- a/frontend/src/pages/post/PostListPage.tsx
+++ b/frontend/src/pages/post/PostListPage.tsx
@@ -21,6 +21,7 @@ import { useWelcomeModal } from '@/hooks/useWelcomeModal';
 import { useQueryClient } from '@tanstack/react-query';
 
 type FeedTab = 'all' | 'following';
+type FeedSort = 'LATEST' | 'POPULAR';
 
 function PostCardSkeleton() {
   return (
@@ -70,11 +71,15 @@ export default function PostListPage() {
     isInfiniteMode ? consumeSnapshot() : null,
   );
 
+  // 뒤로가기 복원 시 snapshot에 저장된 sort를 초기값으로 사용.
+  const [sort, setSort] = useState<FeedSort>(initialSnapshotRef.current?.sort ?? 'LATEST');
+
   const qc = useQueryClient();
 
   const infinite = useInfiniteFeed({
     size: 20,
     enabled: isInfiniteMode,
+    sort,
     initialSnapshot: initialSnapshotRef.current
       ? {
           items: initialSnapshotRef.current.items,
@@ -160,7 +165,14 @@ export default function PostListPage() {
       nextCursor: infinite.nextCursor,
       hasNext: infinite.hasNext,
       scrollY: window.scrollY,
+      sort,
     });
+  }
+
+  function handleSortChange(next: FeedSort) {
+    if (next === sort) return;
+    setSort(next);
+    window.scrollTo({ top: 0, behavior: 'instant' as ScrollBehavior });
   }
 
   function handleFilterClick(value: TherapyArea | '') {
@@ -258,6 +270,32 @@ export default function PostListPage() {
       <div className="p-4 border-b border-gray-200">
         <FilterChips value={therapyArea} onChange={handleFilterClick} />
       </div>
+
+      {/* 정렬 전환 — 무한스크롤 모드(전체 피드 + 필터 없음)에서만 노출 */}
+      {isInfiniteMode && (
+        <div className="flex px-4 py-2 gap-2 border-b border-gray-200 bg-white">
+          <button
+            onClick={() => handleSortChange('LATEST')}
+            className={`text-xs px-3 py-1 rounded-full border transition-colors ${
+              sort === 'LATEST'
+                ? 'bg-gray-900 text-white border-gray-900'
+                : 'text-gray-500 border-gray-300 hover:border-gray-400'
+            }`}
+          >
+            최신순
+          </button>
+          <button
+            onClick={() => handleSortChange('POPULAR')}
+            className={`text-xs px-3 py-1 rounded-full border transition-colors ${
+              sort === 'POPULAR'
+                ? 'bg-gray-900 text-white border-gray-900'
+                : 'text-gray-500 border-gray-300 hover:border-gray-400'
+            }`}
+          >
+            인기순
+          </button>
+        </div>
+      )}
 
       {/* 피드 콘텐츠 */}
       {activeTab === 'all' ? (

--- a/frontend/src/stores/feedScrollStore.ts
+++ b/frontend/src/stores/feedScrollStore.ts
@@ -9,6 +9,7 @@ interface FeedSnapshot {
   hasNext: boolean;
   scrollY: number;
   savedAt: number;
+  sort: 'LATEST' | 'POPULAR';
 }
 
 interface FeedScrollState {


### PR DESCRIPTION
## 관련 이슈
MEL-47

## 변경 내용

### feedScrollStore.ts
- `FeedSnapshot`에 `sort` 필드 추가
- 뒤로가기 복원 시 정렬 상태(최신순/인기순)도 함께 유지

### useInfiniteFeed.ts
- `sort?: 'LATEST' | 'POPULAR'` 옵션 추가 (기본값: `'LATEST'`)
- `queryKey`에 `sort` 포함 → sort별 별도 RQ 캐시 슬롯 → **정렬 전환 시 커서 자동 초기화** (별도 로직 불필요)
- `fetchFeed()` 호출 시 `sort` 파라미터 전달

### PostListPage.tsx
- 필터 칩 하단에 **최신순 / 인기순** 전환 버튼 추가 (무한스크롤 모드에서만 노출)
- `sort` state 초기값을 `initialSnapshotRef.current?.sort`에서 복원 → 뒤로가기 시 정렬 유지
- `handleCardClick`에 `sort` 포함하여 snapshot 저장
- 정렬 변경 시 스크롤 최상단으로 이동

## 동작 흐름

```
인기순 선택 + 스크롤
  → 게시글 클릭 시 snapshot { items, nextCursor, scrollY, sort:'POPULAR' } 저장
  → 뒤로가기
  → consumeSnapshot() → sort='POPULAR' 읽음
  → useState 초기값 'POPULAR' → useInfiniteFeed(sort='POPULAR')
  → RQ queryKey 매칭 + initialData 복원 + 스크롤 위치 복원
```

## 테스트 체크리스트
- [ ] 최신순 → 인기순 전환 시 피드 첫 페이지부터 다시 로드되는지
- [ ] 인기순 상태에서 게시글 클릭 → 뒤로가기 시 인기순 + 스크롤 위치 유지되는지
- [ ] 필터 칩 선택 시 정렬 버튼이 사라지는지 (페이지네이션 모드)
- [ ] 팔로우 탭 전환 시 정렬 버튼이 사라지는지