### PR TITLE
[fix] MEL-45 프로필 이미지 1시간 후 깨지는 버그 수정

### DIFF
--- a/frontend/src/api/axiosInstance.ts
+++ b/frontend/src/api/axiosInstance.ts
@@ -78,6 +78,13 @@ axiosInstance.interceptors.response.use(
       axiosInstance.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
       originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
 
+      // profileImageUrl은 presigned URL (TTL ~1h). refresh마다 /me를 백그라운드 호출해
+      // store를 갱신하지 않으면 1시간 후 이미지가 깨짐 (MEL-45).
+      // 백엔드 RefreshResponse에 user 필드가 추가되면 이 호출은 제거 가능.
+      axiosInstance.get('/me').then((res) => {
+        useAuthStore.getState().setUser(res.data);
+      }).catch(() => {});
+
       processQueue(null, newAccessToken);
       return axiosInstance(originalRequest);
     } catch (refreshError) {

--- a/frontend/src/api/axiosInstance.ts
+++ b/frontend/src/api/axiosInstance.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import type { InternalAxiosRequestConfig } from 'axios';
 import { useAuthStore } from '../stores/useAuthStore';
+import type { RefreshResponse } from '../types/auth';
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -69,21 +70,17 @@ axiosInstance.interceptors.response.use(
       // _retry: true를 붙여서 refresh 요청의 401이 다시 토큰 갱신 로직을 타지 않도록 함.
       // 없으면 refresh 401 → isRefreshing 중이라 failedQueue 진입 → processQueue 호출 불가 → 데드락.
       // TODO: 리팩토링 시 refresh 전용 axios 인스턴스 분리로 대체 (관심사 분리)
-      const { data } = await axiosInstance.post('/auth/refresh', null, {
+      const { data } = await axiosInstance.post<RefreshResponse>('/auth/refresh', null, {
         _retry: true,
       } as any);
       const newAccessToken: string = data.accessToken;
 
       useAuthStore.getState().setTokens({ accessToken: newAccessToken });
+      // profileImageUrl은 presigned URL (TTL ~1h). refresh 응답에 user가 포함되어 있으므로
+      // store를 갱신해 URL 만료 방지 (MEL-45).
+      useAuthStore.getState().setUser(data.user);
       axiosInstance.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
       originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
-
-      // profileImageUrl은 presigned URL (TTL ~1h). refresh마다 /me를 백그라운드 호출해
-      // store를 갱신하지 않으면 1시간 후 이미지가 깨짐 (MEL-45).
-      // 백엔드 RefreshResponse에 user 필드가 추가되면 이 호출은 제거 가능.
-      axiosInstance.get('/me').then((res) => {
-        useAuthStore.getState().setUser(res.data);
-      }).catch(() => {});
 
       processQueue(null, newAccessToken);
       return axiosInstance(originalRequest);

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -30,6 +30,12 @@ export interface LoginResponse {
   tokens: Tokens;
 }
 
+export interface RefreshResponse {
+  accessToken: string;
+  accessTokenExpiresInSec: number;
+  user: MeResponse;
+}
+
 export interface SignupResponse {
   id: number;
   email: string;


### PR DESCRIPTION
## 문제
로그인 후 1시간이 지나면 우측 상단 프로필 이미지가 깨지는 버그.

**원인**: `profileImageUrl`은 presigned GET URL (TTL ~1h)로 로그인 시 store에 저장됨. AT refresh 시 기존 interceptor는 `accessToken`만 갱신하고 `user` 정보는 그대로라 URL이 만료된 채로 방치됨.

## 해결
staging Swagger 확인 결과 백엔드 `RefreshResponse`에 이미 `user` 필드 포함됨.

refresh 성공 시 응답의 `data.user`로 store를 바로 갱신:

```ts
useAuthStore.getState().setUser(data.user);
```

추가 API 호출 없이 해결.

## 변경 파일
- `api/axiosInstance.ts`: refresh 인터셉터에 `setUser(data.user)` 추가, 제네릭 타입 지정
- `types/auth.ts`: `RefreshResponse` 타입 추가

## 테스트
1. staging에서 로그인 후 프로필 이미지 등록
2. AT 만료 시점(~30분) 이후 아무 API 호출로 refresh 트리거
3. DevTools Network에서 `/auth/refresh` 응답에 `user.profileImageUrl` 포함 확인
4. 로그인 1시간 이후에도 이미지 정상 표시 확인

## 관련
- MEL-45
- MEL-25 (우측 상단 이미지 미반영) — refresh 이후 케이스는 이 PR로 해소