### PR TITLE
fix(notification): 컨벤션 리뷰 후속 (unwrap·401·RQ·에러 처리)

### DIFF
--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -9,12 +9,12 @@ export async function fetchNotifications(
   size = 20,
 ): Promise<PaginatedNotifications> {
   const res = await axiosInstance.get('/notifications', { params: { page, size } });
-  return res.data;
+  return res.data?.data ?? res.data;
 }
 
 export async function fetchUnreadCount(): Promise<UnreadCountResponse> {
   const res = await axiosInstance.get('/notifications/unread-count');
-  return res.data;
+  return res.data?.data ?? res.data;
 }
 
 export async function markNotificationAsRead(notificationId: number): Promise<void> {

--- a/frontend/src/hooks/useNotificationSSE.ts
+++ b/frontend/src/hooks/useNotificationSSE.ts
@@ -102,8 +102,8 @@ export function useNotificationSSE() {
             const notification = JSON.parse(event.data) as NotificationResponse;
             store.getState().addNotification(notification);
             toast(notification.content, { duration: 4000 });
-          } catch {
-            // 파싱 실패 무시
+          } catch (err) {
+            console.warn('알림 이벤트 파싱 실패:', err);
           }
         }
       },
@@ -143,8 +143,9 @@ export function useNotificationSSE() {
     try {
       const { count } = await fetchUnreadCount();
       store.getState().setUnreadCount(count);
-    } catch {
-      // 조회 실패 무시
+    } catch (err) {
+      // 401은 axios 인터셉터가 refresh로 흡수합니다. 그 외 일시 장애는 토스트 없이 로깅만 합니다.
+      console.warn('unreadCount 동기화 실패:', err);
     }
   }
 }

--- a/frontend/src/hooks/useNotificationSSE.ts
+++ b/frontend/src/hooks/useNotificationSSE.ts
@@ -5,7 +5,6 @@ import { useNotificationStore } from '../stores/useNotificationStore';
 import { fetchUnreadCount } from '../api/notifications';
 import { connectSSE, type SseConnection } from '../lib/sseClient';
 import type { NotificationResponse } from '../types/notification';
-import axiosInstance from '../api/axiosInstance';
 
 const SSE_URL = `${import.meta.env.VITE_API_BASE_URL}/notifications/subscribe`;
 
@@ -25,7 +24,6 @@ const BACKOFF_MULTIPLIER = 2;
  */
 export function useNotificationSSE() {
   const tokens = useAuthStore((s) => s.tokens);
-  const clearAuth = useAuthStore((s) => s.clearAuth);
 
   const store = useNotificationStore;
   const connectionRef = useRef<SseConnection | null>(null);
@@ -114,9 +112,11 @@ export function useNotificationSSE() {
 
         if (!isActiveRef.current) return;
 
-        // 401 → 토큰 갱신 시도
+        // 401 → 일반 REST 호출로 axios 인터셉터의 refresh 사이클을 트리거합니다.
+        // 인터셉터가 토큰을 갱신하면 useAuthStore.tokens가 바뀌고, useEffect가 재실행되어 재연결됩니다.
+        // 실패 시에는 인터셉터가 clearAuth를 호출하므로 여기서는 따로 처리하지 않습니다.
         if (error.message === 'SSE_HTTP_401') {
-          handleTokenRefresh(accessToken);
+          syncUnreadCount(accessToken);
           return;
         }
 
@@ -125,17 +125,6 @@ export function useNotificationSSE() {
       },
       lastEventId,
     );
-  }
-
-  async function handleTokenRefresh(_expiredToken: string) {
-    try {
-      const { data } = await axiosInstance.post('/auth/refresh');
-      const newToken: string = data.accessToken;
-      useAuthStore.getState().setTokens({ accessToken: newToken });
-      // useEffect가 tokens 변경을 감지하여 재연결함
-    } catch {
-      clearAuth();
-    }
   }
 
   function scheduleReconnect(accessToken: string) {

--- a/frontend/src/pages/notification/NotificationPage.tsx
+++ b/frontend/src/pages/notification/NotificationPage.tsx
@@ -1,5 +1,12 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { Trash2 } from 'lucide-react';
 import PageHeader from '../../components/common/PageHeader';
 import Pagination from '../../components/common/Pagination';
@@ -11,64 +18,129 @@ import {
   deleteNotification,
 } from '../../api/notifications';
 import { getNotificationRoute } from '../../utils/notificationRoute';
-import type { NotificationResponse } from '../../types/notification';
+import type {
+  NotificationResponse,
+  PaginatedNotifications,
+} from '../../types/notification';
+
+const PAGE_SIZE = 20;
 
 export default function NotificationPage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const storeMarkAsRead = useNotificationStore((s) => s.markAsRead);
   const storeMarkAllAsRead = useNotificationStore((s) => s.markAllAsRead);
   const storeRemove = useNotificationStore((s) => s.removeNotification);
   const unreadCount = useNotificationStore((s) => s.unreadCount);
 
-  const [notifications, setNotifications] = useState<NotificationResponse[]>([]);
   const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
-  const [loading, setLoading] = useState(true);
+  const queryKey = ['notifications', page - 1] as const;
 
-  useEffect(() => {
-    loadPage(page);
-  }, [page]);
+  const notificationsQuery = useQuery({
+    queryKey,
+    queryFn: () => fetchNotifications(page - 1, PAGE_SIZE),
+    staleTime: 30_000,
+    placeholderData: keepPreviousData,
+  });
 
-  async function loadPage(p: number) {
-    setLoading(true);
-    try {
-      const data = await fetchNotifications(p - 1, 20);
-      setNotifications(data.items);
-      setTotalPages(Math.max(1, data.totalPages ?? Math.ceil(data.totalElements / data.size)));
-    } catch {
-      // 조회 실패 시 빈 목록 유지
-    } finally {
-      setLoading(false);
-    }
-  }
+  const data = notificationsQuery.data;
+  const notifications = data?.items ?? [];
+  const totalPages = data
+    ? Math.max(1, data.totalPages ?? Math.ceil(data.totalElements / data.size))
+    : 1;
+  const loading = notificationsQuery.isLoading;
+
+  // 옵티미스틱 업데이트는 RQ 캐시(현재 페이지)와 store(unreadCount 동기화) 둘 다 갱신합니다.
+  // 실패 시 캐시는 롤백되지만 store unreadCount는 다음 SSE/페이지 전환 시 자연 보정에 맡깁니다.
+  const markAsReadMutation = useMutation({
+    mutationFn: markNotificationAsRead,
+    onMutate: (id: number) => {
+      storeMarkAsRead(id);
+      const previous = queryClient.getQueryData<PaginatedNotifications>(queryKey);
+      queryClient.setQueryData<PaginatedNotifications>(queryKey, (old) =>
+        old
+          ? {
+              ...old,
+              items: old.items.map((n) =>
+                n.id === id ? { ...n, read: true, readAt: new Date().toISOString() } : n,
+              ),
+            }
+          : old,
+      );
+      return { previous };
+    },
+    onError: (err, _id, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+      console.error('알림 읽음 처리 실패:', err);
+      toast.error('알림을 읽음 처리하지 못했습니다.');
+    },
+  });
+
+  const markAllAsReadMutation = useMutation({
+    mutationFn: markAllNotificationsAsRead,
+    onMutate: () => {
+      storeMarkAllAsRead();
+      const previous = queryClient.getQueryData<PaginatedNotifications>(queryKey);
+      queryClient.setQueryData<PaginatedNotifications>(queryKey, (old) =>
+        old
+          ? {
+              ...old,
+              items: old.items.map((n) => ({
+                ...n,
+                read: true,
+                readAt: n.readAt ?? new Date().toISOString(),
+              })),
+            }
+          : old,
+      );
+      return { previous };
+    },
+    onError: (err, _v, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+      console.error('모두 읽음 처리 실패:', err);
+      toast.error('모두 읽음 처리하지 못했습니다.');
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (vars: { id: number; wasUnread: boolean }) =>
+      deleteNotification(vars.id),
+    onMutate: ({ id, wasUnread }) => {
+      storeRemove(id, wasUnread);
+      const previous = queryClient.getQueryData<PaginatedNotifications>(queryKey);
+      queryClient.setQueryData<PaginatedNotifications>(queryKey, (old) =>
+        old ? { ...old, items: old.items.filter((n) => n.id !== id) } : old,
+      );
+      return { previous };
+    },
+    onError: (err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+      console.error('알림 삭제 실패:', err);
+      toast.error('알림을 삭제하지 못했습니다.');
+    },
+  });
 
   function handleClick(n: NotificationResponse) {
     if (!n.read) {
-      storeMarkAsRead(n.id);
-      setNotifications((prev) =>
-        prev.map((item) =>
-          item.id === n.id ? { ...item, read: true, readAt: new Date().toISOString() } : item,
-        ),
-      );
-      markNotificationAsRead(n.id).catch(() => {});
+      markAsReadMutation.mutate(n.id);
     }
     const route = getNotificationRoute(n.type, n.referenceId);
     navigate(route);
   }
 
-  async function handleMarkAllRead() {
-    storeMarkAllAsRead();
-    setNotifications((prev) =>
-      prev.map((n) => ({ ...n, read: true, readAt: n.readAt ?? new Date().toISOString() })),
-    );
-    markAllNotificationsAsRead().catch(() => {});
+  function handleMarkAllRead() {
+    markAllAsReadMutation.mutate();
   }
 
-  async function handleDelete(e: React.MouseEvent, n: NotificationResponse) {
+  function handleDelete(e: React.MouseEvent, n: NotificationResponse) {
     e.stopPropagation();
-    storeRemove(n.id, !n.read);
-    setNotifications((prev) => prev.filter((item) => item.id !== n.id));
-    deleteNotification(n.id).catch(() => {});
+    deleteMutation.mutate({ id: n.id, wasUnread: !n.read });
   }
 
   return (


### PR DESCRIPTION
## Summary

알림 기능(`feat/notification` cherry-pick 머지분)에 대한 컨벤션 정합 리뷰 결과 중 HIGH 4건을 처리합니다.

- **H1 — API 응답 unwrap 방어** (`api/notifications.ts`)
  - `fetchNotifications`, `fetchUnreadCount`에 `res.data?.data ?? res.data` 패턴 적용. `api/posts.ts:44,107,116,...` 등 기존 도메인과 정합.
- **H2 — 401 처리 axios 인터셉터 위임** (`hooks/useNotificationSSE.ts`)
  - SSE 훅의 자체 `/auth/refresh` 호출 제거. 401 발생 시 일반 REST(`fetchUnreadCount`)를 호출해 인터셉터의 refresh 사이클을 트리거하고, `useAuthStore.tokens` 변경을 감지한 `useEffect`가 자동 재연결. 실패 시 인터셉터가 `clearAuth` 처리. 인터셉터 ↔ SSE 훅 사이의 refresh 경쟁 조건 해소.
- **H4 — NotificationPage React Query 마이그레이션** (`pages/notification/NotificationPage.tsx`)
  - `useState + useEffect` 수동 fetch → `useQuery` (`queryKey: ['notifications', page-1]`, `staleTime: 30s`, `keepPreviousData`).
  - read / mark-all / delete 액션 → `useMutation` 옵티미스틱: `onMutate`에서 store + 캐시 갱신, `onError`에서 캐시 롤백 + `toast.error`. `ProfilePage` RQ 패턴과 정합.
- **H5 — 에러 catch 처리**
  - NotificationPage 4곳의 무음 catch는 H4 mutation `onError`로 흡수(`console.error` + 사용자 토스트).
  - `useNotificationSSE`의 JSON.parse / unreadCount 동기화 catch는 `console.warn` 로깅. 백그라운드 동작이라 토스트 미적용, 401은 H2가 흡수.

리뷰에서 HIGH 3(`@microsoft/fetch-event-source` 결정 정합), MID/LOW 항목은 별개 결정/이슈로 남깁니다.

## 변경 파일

- `frontend/src/api/notifications.ts` (+2/-2)
- `frontend/src/hooks/useNotificationSSE.ts` (+8/-18)
- `frontend/src/pages/notification/NotificationPage.tsx` (+109/-37)

## Test plan

- [ ] `npx tsc -b` 통과 (이미 확인)
- [ ] staging 백엔드 붙여서 `/notifications` 응답이 `{ success, data }` 래퍼 / 비래퍼 어느 형태든 unwrap 정상 동작
- [ ] 알림 페이지 로드 → 페이지네이션 이동 시 이전 페이지 데이터가 keepPreviousData로 잠시 보이고 새 데이터로 교체
- [ ] 알림 클릭 → 옵티미스틱하게 read 표시되고 라우팅, 네트워크 실패 시 캐시 롤백 + 토스트
- [ ] "모두 읽음" 클릭 → 모든 알림 옵티미스틱 read, 실패 시 롤백 + 토스트
- [ ] 휴지통 클릭 → 옵티미스틱 제거, 실패 시 롤백 + 토스트
- [ ] 토큰 만료(AT 15분) → SSE 401 발생 시 인터셉터 refresh + 자동 재연결, refresh 실패 시 로그아웃
- [ ] SSE 도착 알림 토스트 정상 표시 / 잘못된 JSON 이벤트 수신 시 console.warn만 출력하고 연결 유지