### PR TITLE
feat(message): 쪽지 보내기 e2e (slice 1)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import PostCreatePage from './pages/post/PostCreatePage';
 import PostEditPage from './pages/post/PostEditPage';
 import CommentWritePage from './pages/post/CommentWritePage';
 import CommentDetailPage from './pages/post/CommentDetailPage';
+import MessageComposePage from './pages/message/MessageComposePage';
 import SearchPage from './pages/search/SearchPage';
 import ProfilePage from './pages/profile/ProfilePage';
 import NotificationPage from './pages/notification/NotificationPage';
@@ -79,6 +80,8 @@ function App() {
             <Route path="/search" element={<SearchPage />} />
             <Route path="/notifications" element={<NotificationPage />} />
             <Route path="/profile" element={<ProfilePage />} />
+            {/* 모바일 쪽지 작성. slice 2에서 /messages/:messageId 추가 시 그보다 먼저 배치 유지 */}
+            <Route path="/messages/new" element={<MessageComposePage />} />
           </Route>
 
           <Route path="/my-page" element={<Navigate to="/profile" replace />} />

--- a/frontend/src/components/common/UserActionDropdown.tsx
+++ b/frontend/src/components/common/UserActionDropdown.tsx
@@ -30,19 +30,19 @@ function UserActionDropdown({
   }
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger aria-label={`${nickname}님 메뉴`} onClick={(e) => e.stopPropagation()}>
         <UserAvatar nickname={nickname} imageUrl={imageUrl} size={size} />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" onClick={(e) => e.stopPropagation()}>
         <DropdownMenuItem
-          onClick={() => toast('준비 중인 기능이에요')}
+          onClick={() => toast('준비 중인 기능이에요', { id: 'coming-soon' })}
           className="text-gray-400"
         >
           프로필
         </DropdownMenuItem>
         <DropdownMenuItem
-          onClick={() => toast('준비 중인 기능이에요')}
+          onClick={() => toast('준비 중인 기능이에요', { id: 'coming-soon' })}
           className="text-gray-400"
         >
           팔로우

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import { toast } from 'sonner';
 import { Outlet, Link, useLocation } from 'react-router-dom';
 import { HomeIcon, SearchIcon, WriteIcon, BellIcon, ProfileIcon } from '@/components/icons';
 import { useAuthStore } from '../../stores/useAuthStore';
@@ -14,6 +16,11 @@ export default function Layout() {
 
   // 모바일 글쓰기 페이지(/posts/new)는 풀스크린 시안 — BottomNav가 하단 툴바를 가리지 않도록 숨김.
   const hideBottomNav = location.pathname === '/posts/new';
+
+  // 라우트 변경 시 토스트 닫기
+  useEffect(() => {
+    toast.dismiss();
+  }, [location.pathname]);
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -4,6 +4,7 @@ import { useAuthStore } from '../../stores/useAuthStore';
 import { useNotificationStore } from '../../stores/useNotificationStore';
 import SideNav from './SideNav';
 import PostWriteModal from '../post/PostWriteModal';
+import MessageComposeModal from '../message/MessageComposeModal';
 
 export default function Layout() {
   const location = useLocation();
@@ -24,6 +25,9 @@ export default function Layout() {
 
       {/* PC 게시글 작성 모달 — 진입점(SideNav, PostListPage 글쓰기 버튼)에서 store로 토글 */}
       <PostWriteModal />
+
+      {/* PC 쪽지 작성 모달 — 진입점(작성자 프사 드롭다운)에서 messageComposeStore로 토글 */}
+      <MessageComposeModal />
 
       {/* Bottom Navigation (Mobile) */}
       {!hideBottomNav && (

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -4,7 +4,7 @@ import { useAuthStore } from '../../stores/useAuthStore';
 import { useNotificationStore } from '../../stores/useNotificationStore';
 import SideNav from './SideNav';
 import PostWriteModal from '../post/PostWriteModal';
-import MessageComposeModal from '../message/MessageComposeModal';
+import MessageComposeModalGate from '../message/MessageComposeModalGate';
 
 export default function Layout() {
   const location = useLocation();
@@ -26,8 +26,8 @@ export default function Layout() {
       {/* PC 게시글 작성 모달 — 진입점(SideNav, PostListPage 글쓰기 버튼)에서 store로 토글 */}
       <PostWriteModal />
 
-      {/* PC 쪽지 작성 모달 — 진입점(작성자 프사 드롭다운)에서 messageComposeStore로 토글 */}
-      <MessageComposeModal />
+      {/* PC 쪽지 작성 모달 — 게이트가 open일 때만 조건부 마운트(닫히면 언마운트→state 자동 청소) */}
+      <MessageComposeModalGate />
 
       {/* Bottom Navigation (Mobile) */}
       {!hideBottomNav && (

--- a/frontend/src/components/message/MessageComposeModal.tsx
+++ b/frontend/src/components/message/MessageComposeModal.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import { ArrowLeft, PencilLine } from 'lucide-react';
+import { useMessageComposeStore } from '../../stores/messageComposeStore';
+import { useSendMessage, MESSAGE_MAX_LENGTH } from '../../hooks/useSendMessage';
+
+// PC 전용 쪽지 작성 모달. 루트(Layout)에 항상 마운트되어 store의 open으로 토글.
+// 모바일은 /messages/new?to=:id 라우트(MessageComposePage)로 분기하므로 이 모달과 무관.
+// 정답지: CommentReplyModal(chrome/IME 가드) + PostWriteModal(store 토글/스크롤 잠금).
+export default function MessageComposeModal() {
+  const open = useMessageComposeStore((s) => s.open);
+  const receiverId = useMessageComposeStore((s) => s.receiverId);
+  const receiverNickname = useMessageComposeStore((s) => s.receiverNickname);
+  const closeCompose = useMessageComposeStore((s) => s.closeCompose);
+
+  const [content, setContent] = useState('');
+  const { submitting, send } = useSendMessage({ onSuccess: closeCompose });
+
+  // 닫힐 때 입력값 리셋 — 항상 마운트된 모달이라 content가 살아남는다.
+  // 외부 closeCompose() 직접 호출도 일관 커버하도록 open=false를 트리거로 비운다.
+  useEffect(() => {
+    if (!open) setContent('');
+  }, [open]);
+
+  // ESC로 닫기 + body 스크롤 잠금 (열려있는 동안만).
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') closeCompose();
+    }
+    document.addEventListener('keydown', onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open, closeCompose]);
+
+  if (!open || receiverId == null) return null;
+
+  const canSubmit = content.trim().length > 0 && !submitting;
+
+  function handleSubmit() {
+    if (receiverId == null) return;
+    send(receiverId, content);
+  }
+
+  // CommentReplyModal과 동일한 IME 중복 발화 방어 + Enter=제출, Shift+Enter=줄바꿈. PC 전용.
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.nativeEvent.isComposing) return;
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      if (canSubmit) handleSubmit();
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center px-4"
+      // mousedown 기준 닫기 — 모달 내부에서 시작한 드래그가 배경에서 끝나도 닫힘으로 인식되는 사고 방지.
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) closeCompose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="message-compose-modal-title"
+        className="w-full max-w-[520px] max-h-[90vh] bg-white rounded-2xl shadow-[0px_4px_20px_0px_rgba(0,0,0,0.15)] overflow-hidden flex flex-col"
+      >
+        {/* 헤더 — ← (close) / 가운데 타이틀 / ✏️ (submit). CommentReplyModal 동일 패턴 */}
+        <header className="flex items-center justify-between px-4 py-3 border-b border-gray-100 shrink-0">
+          <button
+            type="button"
+            onClick={closeCompose}
+            aria-label="닫기"
+            className="p-1 -ml-1 text-gray-700 hover:text-gray-900 transition-colors"
+          >
+            <ArrowLeft size={20} />
+          </button>
+          <h1 id="message-compose-modal-title" className="text-base font-semibold text-gray-900">
+            쪽지
+          </h1>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            aria-label="쪽지 보내기"
+            className="p-1 -mr-1 text-gray-900 hover:text-black transition-colors disabled:text-gray-300 disabled:cursor-not-allowed"
+          >
+            <PencilLine size={20} />
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto px-4 py-4 flex flex-col">
+          {/* 받는 사람 컨텍스트 — 드롭다운에서 넘어온 닉네임 표시 */}
+          <p className="text-sm text-gray-500 mb-3">
+            받는 사람 · <span className="font-semibold text-gray-900">{receiverNickname}</span>
+          </p>
+
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="쪽지를 입력하세요..."
+            maxLength={MESSAGE_MAX_LENGTH}
+            rows={5}
+            autoFocus
+            disabled={submitting}
+            className="w-full resize-none rounded-2xl bg-gray-100 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 disabled:opacity-50"
+          />
+          <p className="text-xs text-gray-400 text-right mt-1">
+            {content.length} / {MESSAGE_MAX_LENGTH}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/message/MessageComposeModal.tsx
+++ b/frontend/src/components/message/MessageComposeModal.tsx
@@ -3,11 +3,11 @@ import { ArrowLeft, PencilLine } from 'lucide-react';
 import { useMessageComposeStore } from '../../stores/messageComposeStore';
 import { useSendMessage, MESSAGE_MAX_LENGTH } from '../../hooks/useSendMessage';
 
-// PC 전용 쪽지 작성 모달. 루트(Layout)에 항상 마운트되어 store의 open으로 토글.
+// PC 전용 쪽지 작성 모달. MessageComposeModalGate가 open일 때만 마운트하므로
+// 이 컴포넌트는 "열린 상태"만 그린다. 닫히면 게이트가 언마운트시켜 content 등 로컬 state가 자동 청소된다.
 // 모바일은 /messages/new?to=:id 라우트(MessageComposePage)로 분기하므로 이 모달과 무관.
 // 정답지: CommentReplyModal(chrome/IME 가드) + PostWriteModal(store 토글/스크롤 잠금).
 export default function MessageComposeModal() {
-  const open = useMessageComposeStore((s) => s.open);
   const receiverId = useMessageComposeStore((s) => s.receiverId);
   const receiverNickname = useMessageComposeStore((s) => s.receiverNickname);
   const closeCompose = useMessageComposeStore((s) => s.closeCompose);
@@ -15,15 +15,8 @@ export default function MessageComposeModal() {
   const [content, setContent] = useState('');
   const { submitting, send } = useSendMessage({ onSuccess: closeCompose });
 
-  // 닫힐 때 입력값 리셋 — 항상 마운트된 모달이라 content가 살아남는다.
-  // 외부 closeCompose() 직접 호출도 일관 커버하도록 open=false를 트리거로 비운다.
+  // ESC로 닫기 + body 스크롤 잠금. 마운트=열린 상태이므로 가드 없이 항상 설치한다.
   useEffect(() => {
-    if (!open) setContent('');
-  }, [open]);
-
-  // ESC로 닫기 + body 스크롤 잠금 (열려있는 동안만).
-  useEffect(() => {
-    if (!open) return;
     function onKey(e: KeyboardEvent) {
       if (e.key === 'Escape') closeCompose();
     }
@@ -34,9 +27,9 @@ export default function MessageComposeModal() {
       document.removeEventListener('keydown', onKey);
       document.body.style.overflow = prevOverflow;
     };
-  }, [open, closeCompose]);
+  }, [closeCompose]);
 
-  if (!open || receiverId == null) return null;
+  if (receiverId == null) return null;
 
   const canSubmit = content.trim().length > 0 && !submitting;
 

--- a/frontend/src/components/message/MessageComposeModalGate.tsx
+++ b/frontend/src/components/message/MessageComposeModalGate.tsx
@@ -1,0 +1,12 @@
+import { useMessageComposeStore } from '../../stores/messageComposeStore';
+import MessageComposeModal from './MessageComposeModal';
+
+// 쪽지 작성 모달의 조건부 마운트 게이트.
+// open만 구독해 열렸을 때만 모달을 마운트하고, 닫히면 언마운트시킨다.
+// → 모달 내부 content 등 로컬 state가 자동 청소되어 수동 리셋 effect가 필요 없다.
+// state를 들지 않는 얇은 컴포넌트라, Layout이 직접 open을 구독할 때 생기는
+// "모달 열 때마다 페이지 전체 리렌더" 비용을 게이트+모달 범위로 좁힌다.
+export default function MessageComposeModalGate() {
+  const open = useMessageComposeStore((s) => s.open);
+  return open ? <MessageComposeModal /> : null;
+}

--- a/frontend/src/components/post/CommentCard.tsx
+++ b/frontend/src/components/post/CommentCard.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from 'react';
 import { MessageSquare, MoreHorizontal } from 'lucide-react';
 import type { CommentResponse, ReactionType } from '../../types/post';
 import { formatRelativeTime } from '../../utils/formatDate';
-import UserAvatar from '../common/UserAvatar';
+import UserActionDropdown from '../common/UserActionDropdown';
+import { useOpenMessageCompose } from '../../hooks/useOpenMessageCompose';
 import VerifiedBadge from './VerifiedBadge';
 import {
   DropdownMenu,
@@ -50,6 +51,9 @@ export default function CommentCard({
   onToggleReaction,
   toggling,
 }: CommentCardProps) {
+  // 작성자 프사 드롭다운 → 쪽지 진입. 기존 onMessageClick prop(💬 답글 아이콘)과는 별개.
+  const openMessageCompose = useOpenMessageCompose();
+
   // 편집 모드 진입 시 textarea 초기값을 원본으로 채워두는 로컬 state.
   // 부모에 끌어올리지 않는 이유: 입력 중 리렌더 시 keystroke이 부모까지 올라가면 다른 카드의
   // 리액션/페이지 상태까지 흔드는 광범위한 리렌더가 발생함. content는 "편집 중에만" 의미가
@@ -83,10 +87,14 @@ export default function CommentCard({
         {isReply && (
           <div className="self-start h-4 w-3 ml-6 border-l border-b border-gray-300 rounded-bl-lg" />
         )}
-        <UserAvatar
+        <UserActionDropdown
+          targetUserId={comment.authorId}
           nickname={comment.authorNickname}
           imageUrl={comment.authorProfileImageUrl}
           size={isReply ? 'sm' : 'md'}
+          onMessageClick={() =>
+            openMessageCompose({ id: comment.authorId, nickname: comment.authorNickname })
+          }
         />
         {/* 부모 댓글이 자식을 가졌으면 세로선이 카드 하단까지 흐름.
             자식 카드 ╰ 의 vertical 라인과 동일한 x=24 위치(items-center로 가운데). */}

--- a/frontend/src/hooks/useOpenMessageCompose.ts
+++ b/frontend/src/hooks/useOpenMessageCompose.ts
@@ -1,0 +1,18 @@
+import { useNavigate } from 'react-router-dom';
+import { useMessageComposeStore } from '../stores/messageComposeStore';
+
+// 쪽지 작성 진입의 PC/모바일 분기를 한 곳에 모은 헬퍼.
+// PC(>=768px): 전역 store로 모달 토글 / 모바일: /messages/new 라우트로 navigate (CH-09 정책).
+// 모든 진입점(PostDetailPage, CommentCard 등)이 이 hook만 호출하면 분기가 통일된다.
+export function useOpenMessageCompose() {
+  const navigate = useNavigate();
+  const openCompose = useMessageComposeStore((s) => s.openCompose);
+
+  return function open(receiver: { id: number; nickname: string }) {
+    if (window.matchMedia('(min-width: 768px)').matches) {
+      openCompose(receiver);
+    } else {
+      navigate(`/messages/new?to=${receiver.id}&name=${encodeURIComponent(receiver.nickname)}`);
+    }
+  };
+}

--- a/frontend/src/hooks/useSendMessage.ts
+++ b/frontend/src/hooks/useSendMessage.ts
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import axios from 'axios';
+import { toast } from 'sonner';
+import { sendMessage } from '../api/messages';
+import type { MessageResponse } from '../types/message';
+
+// 백엔드 MessageSendRequest.content maxLength=1000 (staging Swagger 2026-06-01 확인).
+// 설계 스펙의 2000은 CommentReplyModal에서 잘못 빌려온 값 → 백엔드 제약에 맞춤.
+export const MESSAGE_MAX_LENGTH = 1000;
+
+interface UseSendMessageOptions {
+  // 발송 성공 시 호출. 모달은 close, 페이지는 navigate 등 후처리를 호출처가 결정.
+  onSuccess?: (message: MessageResponse) => void;
+}
+
+export function useSendMessage({ onSuccess }: UseSendMessageOptions = {}) {
+  const [submitting, setSubmitting] = useState(false);
+
+  async function send(receiverId: number, content: string) {
+    // in-flight 가드: setSubmitting 비동기 배치라 동기 이중 호출(IME Enter 이중 발화, 더블탭)을
+    // 막지 못함. 진입 시점 state로 직접 차단. (useCommentSubmit 동일 패턴)
+    if (submitting) return;
+    const trimmed = content.trim();
+    if (!trimmed) return;
+    // 방어적 상한 — textarea maxLength로도 막지만, 외부 호출 대비 한 번 더.
+    if (trimmed.length > MESSAGE_MAX_LENGTH) {
+      toast.error(`쪽지는 ${MESSAGE_MAX_LENGTH}자까지 보낼 수 있어요.`);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const message = await sendMessage({ receiverId, content: trimmed });
+      toast.success('쪽지를 보냈어요.');
+      onSuccess?.(message);
+    } catch (err) {
+      // 401은 axiosInstance 인터셉터가 흡수하므로 여기 안 옴.
+      // 백엔드가 200 외 에러 코드를 문서화하지 않아(2026-06-01 Swagger) 정확한 원인 매핑 불가.
+      // 보수적으로 4xx(요청 자체 문제 — 없는/차단된 수신자 등)와 그 외(서버·네트워크 일시 문제)만 분기.
+      // 추후 백엔드가 코드 확정하면 세분화.
+      const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+      if (status && status >= 400 && status < 500) {
+        toast.error('받는 사람에게 쪽지를 보낼 수 없어요.');
+      } else {
+        toast.error('쪽지 전송에 실패했어요. 잠시 후 다시 시도해주세요.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return { submitting, send };
+}

--- a/frontend/src/pages/message/MessageComposePage.tsx
+++ b/frontend/src/pages/message/MessageComposePage.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { PencilLine } from 'lucide-react';
+import PageHeader from '../../components/common/PageHeader';
+import { useSendMessage, MESSAGE_MAX_LENGTH } from '../../hooks/useSendMessage';
+
+// 모바일 전용 쪽지 작성 라우트. /messages/new?to=:id&name=:nickname
+// PC는 MessageComposeModal(store)로 분기하므로 이 페이지와 무관.
+// 받는 사람 id는 쿼리 to에서, 표시용 닉네임은 name에서 받는다(store 없이 URL만으로 완결).
+export default function MessageComposePage() {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const to = params.get('to');
+  const receiverNickname = params.get('name');
+
+  const [content, setContent] = useState('');
+  // TODO(slice 2): 보낸함(/messages) 생기면 성공 후 그쪽으로 이동. 현재는 홈 피드로.
+  const { submitting, send } = useSendMessage({ onSuccess: () => navigate('/posts') });
+
+  // to가 누락/비숫자면 작성 불가 — 안내 + 빠져나갈 링크(PostDetailPage 404 가드 패턴).
+  if (!to || isNaN(Number(to))) {
+    return (
+      <div>
+        <PageHeader title="쪽지" backTo="/posts" />
+        <div className="px-4 py-10 text-center">
+          <p className="text-sm text-gray-600">받는 사람을 찾을 수 없어요.</p>
+          <Link to="/posts" className="mt-3 inline-block text-sm text-blue-600 underline">
+            홈으로 돌아가기
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const receiverId = Number(to);
+  const canSubmit = content.trim().length > 0 && !submitting;
+
+  return (
+    <div>
+      <PageHeader
+        title="쪽지"
+        backTo="/posts"
+        rightAction={
+          <button
+            type="button"
+            onClick={() => send(receiverId, content)}
+            disabled={!canSubmit}
+            aria-label="쪽지 보내기"
+            className="text-gray-900 hover:text-black transition-colors disabled:text-gray-300 disabled:cursor-not-allowed"
+          >
+            <PencilLine size={22} />
+          </button>
+        }
+      />
+      <div className="px-4 py-4">
+        <p className="text-sm text-gray-500 mb-3">
+          받는 사람 · <span className="font-semibold text-gray-900">{receiverNickname ?? '상대방'}</span>
+        </p>
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="쪽지를 입력하세요..."
+          maxLength={MESSAGE_MAX_LENGTH}
+          rows={8}
+          autoFocus
+          disabled={submitting}
+          className="w-full resize-none rounded-2xl bg-gray-100 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 disabled:opacity-50"
+        />
+        <p className="text-xs text-gray-400 text-right mt-1">
+          {content.length} / {MESSAGE_MAX_LENGTH}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/post/PostDetailPage.tsx
+++ b/frontend/src/pages/post/PostDetailPage.tsx
@@ -40,7 +40,8 @@ import type { PostDetail, CommentResponse, PostImage } from '../../types/post';
 import { THERAPY_AREA_LABELS } from '../../constants/post';
 import { formatRelativeTime } from '../../utils/formatDate';
 import { resolveImageUrl } from '../../utils/resolveImageUrl';
-import UserAvatar from '../../components/common/UserAvatar';
+import UserActionDropdown from '../../components/common/UserActionDropdown';
+import { useOpenMessageCompose } from '../../hooks/useOpenMessageCompose';
 import PageHeader from '@/components/common/PageHeader';
 import { trackReaction } from '../../lib/analytics';
 import axios from 'axios';
@@ -78,6 +79,7 @@ export default function PostDetailPage() {
 
   const { postId } = useParams<{ postId: string }>();
   const navigate = useNavigate();
+  const openMessageCompose = useOpenMessageCompose();
 
   const [post, setPost] = useState<PostDetail | null>(null);
   const [comments, setComments] = useState<CommentResponse[]>([]);
@@ -307,10 +309,14 @@ export default function PostDetailPage() {
         <div className="bg-white p-4 flex flex-col gap-4">
           {/* 작성자 정보 */}
           <div className="flex items-center gap-3">
-            <UserAvatar
+            <UserActionDropdown
+              targetUserId={post.authorId}
               nickname={post.authorNickname}
               imageUrl={post.authorProfileImageUrl}
               size="md"
+              onMessageClick={() =>
+                openMessageCompose({ id: post.authorId, nickname: post.authorNickname })
+              }
             />
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2">

--- a/frontend/src/stores/messageComposeStore.ts
+++ b/frontend/src/stores/messageComposeStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+
+interface MessageComposeState {
+  open: boolean;
+  // 모달이 열릴 때 누구에게 보낼지. 닫히면 null로 비워 다음 진입에 잔상이 남지 않게 한다.
+  receiverId: number | null;
+  receiverNickname: string | null;
+  // 드롭다운의 "쪽지"에서 호출. 받는 사람을 담으면서 모달을 연다.
+  openCompose: (receiver: { id: number; nickname: string }) => void;
+  // 모달 자신이 닫을 때. 받는 사람 정보도 함께 비운다.
+  closeCompose: () => void;
+}
+
+// PC 쪽지 작성 모달 전역 상태. PostDetailPage/CommentCard 등 여러 진입점이 동일한 모달을 토글.
+// 모바일은 /messages/new?to=:id 라우트로 navigate하므로 이 store와 무관(usePostWriteModalStore 패턴 동일).
+export const useMessageComposeStore = create<MessageComposeState>((set) => ({
+  open: false,
+  receiverId: null,
+  receiverNickname: null,
+  openCompose: (receiver) =>
+    set({ open: true, receiverId: receiver.id, receiverNickname: receiver.nickname }),
+  closeCompose: () => set({ open: false, receiverId: null, receiverNickname: null }),
+}));


### PR DESCRIPTION
## 범위 — slice 1: 쪽지 보내기 end-to-end

작성자 프사 드롭다운 → 쪽지 → 작성창(PC 모달 / 모바일 라우트) → 발송까지.

### 유닛 체크리스트
- [x] 트리거 store (`messageComposeStore`)
- [ ] `useSendMessage` hook (2000자/빈값 가드 + 발송 + 에러 분기)
- [ ] `MessageComposeModal` (PC, store 구독)
- [ ] `MessageComposePage` (모바일, `/messages/new?to=:id`)
- [ ] 진입점 연결 (PostDetailPage, CommentCard)
- [ ] 라우트 등록

### 참고
- 설계 스펙: `docs/superpowers/specs/2026-05-26-user-interaction-messaging-design.md`
- 정답지: `CommentReplyModal`, `PostWriteModal`
- 백엔드: Q2(읽음 처리) Swagger 확인 완료, Q1(referenceId) slice 3에서 런타임 1건 확인 예정

유닛마다 커밋이 쌓이니 커밋별 diff로 리뷰 가능합니다.