### PR TITLE
feat(message): 쪽지함 — 목록(받은/보낸)·상세·삭제 (slice 2)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,8 @@ import PostEditPage from './pages/post/PostEditPage';
 import CommentWritePage from './pages/post/CommentWritePage';
 import CommentDetailPage from './pages/post/CommentDetailPage';
 import MessageComposePage from './pages/message/MessageComposePage';
+import MessageBoxPage from './pages/message/MessageBoxPage';
+import MessageDetailPage from './pages/message/MessageDetailPage';
 import SearchPage from './pages/search/SearchPage';
 import ProfilePage from './pages/profile/ProfilePage';
 import NotificationPage from './pages/notification/NotificationPage';
@@ -80,8 +82,11 @@ function App() {
             <Route path="/search" element={<SearchPage />} />
             <Route path="/notifications" element={<NotificationPage />} />
             <Route path="/profile" element={<ProfilePage />} />
-            {/* 모바일 쪽지 작성. slice 2에서 /messages/:messageId 추가 시 그보다 먼저 배치 유지 */}
+            {/* 쪽지함(받은/보낸 2탭). 상세는 /messages/:messageId */}
+            <Route path="/messages" element={<MessageBoxPage />} />
+            {/* 모바일 쪽지 작성. 정적 경로라 /messages/:messageId보다 먼저 배치 */}
             <Route path="/messages/new" element={<MessageComposePage />} />
+            <Route path="/messages/:messageId" element={<MessageDetailPage />} />
           </Route>
 
           <Route path="/my-page" element={<Navigate to="/profile" replace />} />

--- a/frontend/src/api/messages.ts
+++ b/frontend/src/api/messages.ts
@@ -1,7 +1,39 @@
 import axiosInstance from './axiosInstance';
-import type { MessageResponse, MessageSendRequest } from '../types/message';
+import type {
+    MessageResponse,
+    MessageSendRequest,
+    PagedResponseMessageResponse,
+} from '../types/message';
 
 export async function sendMessage(payload:MessageSendRequest): Promise<MessageResponse> {
     const res = await axiosInstance.post('/messages', payload);
     return res.data?.data ?? res.data;
+}
+
+// 받은 쪽지함 (page/size, 0-based). 정답지: api/notifications.ts fetchNotifications
+export async function fetchReceivedMessages(
+    page = 0,
+    size = 20,
+): Promise<PagedResponseMessageResponse> {
+    const res = await axiosInstance.get('/me/messages/received', { params: { page, size } });
+    return res.data?.data ?? res.data;
+}
+
+// 보낸 쪽지함 (page/size, 0-based)
+export async function fetchSentMessages(
+    page = 0,
+    size = 20,
+): Promise<PagedResponseMessageResponse> {
+    const res = await axiosInstance.get('/me/messages/sent', { params: { page, size } });
+    return res.data?.data ?? res.data;
+}
+
+// 쪽지 상세. 수신자가 조회하면 백엔드가 자동 읽음 처리(스펙 Q2 해소).
+export async function fetchMessageDetail(messageId: number): Promise<MessageResponse> {
+    const res = await axiosInstance.get(`/messages/${messageId}`);
+    return res.data?.data ?? res.data;
+}
+
+export async function deleteMessage(messageId: number): Promise<void> {
+    await axiosInstance.delete(`/messages/${messageId}`);
 }

--- a/frontend/src/pages/message/MessageBoxPage.tsx
+++ b/frontend/src/pages/message/MessageBoxPage.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import PageHeader from '../../components/common/PageHeader';
+import Pagination from '../../components/common/Pagination';
+import { fetchReceivedMessages, fetchSentMessages } from '../../api/messages';
+import type { MessageResponse } from '../../types/message';
+
+const PAGE_SIZE = 20;
+
+type Tab = 'received' | 'sent';
+
+// 받은함/보낸함 2탭. 목록은 React Query로 가져오고(정답지: NotificationPage),
+// 안읽음 카운트는 slice 3에서 store로 별도 관리(목록=RQ / 카운트=store 이원화).
+export default function MessageBoxPage() {
+  const navigate = useNavigate();
+  const [tab, setTab] = useState<Tab>('received');
+  const [page, setPage] = useState(1);
+
+  const queryKey = ['messages', tab, page - 1] as const;
+  const messagesQuery = useQuery({
+    queryKey,
+    queryFn: () =>
+      tab === 'received'
+        ? fetchReceivedMessages(page - 1, PAGE_SIZE)
+        : fetchSentMessages(page - 1, PAGE_SIZE),
+    staleTime: 30_000,
+    placeholderData: keepPreviousData,
+  });
+
+  const data = messagesQuery.data;
+  const messages = data?.items ?? [];
+  const totalPages = data
+    ? Math.max(1, data.totalPages ?? Math.ceil(data.totalElements / data.size))
+    : 1;
+  const loading = messagesQuery.isLoading;
+
+  function switchTab(next: Tab) {
+    if (next === tab) return;
+    setTab(next);
+    setPage(1);
+  }
+
+  return (
+    <div className="pb-20 md:pb-0">
+      <PageHeader title="쪽지함" backTo="/profile" />
+
+      <div className="max-w-2xl mx-auto">
+        {/* 받은함/보낸함 탭 */}
+        <div className="flex border-b border-gray-200">
+          {(
+            [
+              ['received', '받은 쪽지'],
+              ['sent', '보낸 쪽지'],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              onClick={() => switchTab(value)}
+              className={`flex-1 py-3 text-sm font-medium transition-colors ${
+                tab === value
+                  ? 'text-gray-900 border-b-2 border-gray-900'
+                  : 'text-gray-400 hover:text-gray-600'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {loading ? (
+          <div className="px-4 py-12 text-center text-gray-400 text-sm">불러오는 중...</div>
+        ) : messages.length === 0 ? (
+          <div className="px-4 py-12 text-center text-gray-400 text-sm">
+            {tab === 'received' ? '받은 쪽지가 없습니다' : '보낸 쪽지가 없습니다'}
+          </div>
+        ) : (
+          <>
+            <ul>
+              {messages.map((m) => (
+                <MessageRow
+                  key={m.messageId}
+                  message={m}
+                  tab={tab}
+                  onClick={() => navigate(`/messages/${m.messageId}`)}
+                />
+              ))}
+            </ul>
+
+            {totalPages > 1 && (
+              <Pagination currentPage={page} totalPages={totalPages} onPageChange={setPage} />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface MessageRowProps {
+  message: MessageResponse;
+  tab: Tab;
+  onClick: () => void;
+}
+
+function MessageRow({ message, tab, onClick }: MessageRowProps) {
+  // 받은함이면 보낸 사람, 보낸함이면 받는 사람을 상대방으로 표시.
+  const counterpart = tab === 'received' ? message.senderNickname : message.receiverNickname;
+  // 안읽음 강조는 받은함에서만 의미 있음(보낸함의 read는 "상대가 읽었는지"라 강조 대상 아님).
+  const highlightUnread = tab === 'received' && !message.read;
+
+  return (
+    <li
+      onClick={onClick}
+      className={`flex items-start gap-3 px-4 py-4 border-b border-gray-100 cursor-pointer transition-colors ${
+        highlightUnread ? 'bg-blue-50/40 hover:bg-blue-50' : 'bg-white hover:bg-gray-50'
+      }`}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span
+            className={`text-sm truncate ${
+              highlightUnread ? 'font-semibold text-gray-900' : 'font-medium text-gray-700'
+            }`}
+          >
+            {counterpart}
+          </span>
+          {message.broadcast && (
+            <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+              공지
+            </span>
+          )}
+        </div>
+        <p
+          className={`mt-1 text-sm leading-snug line-clamp-2 ${
+            highlightUnread ? 'text-gray-800' : 'text-gray-500'
+          }`}
+        >
+          {message.content}
+        </p>
+        <p className="mt-1 text-xs text-gray-400">
+          {new Date(message.createdAt).toLocaleString('ko-KR')}
+        </p>
+      </div>
+    </li>
+  );
+}

--- a/frontend/src/pages/message/MessageComposePage.tsx
+++ b/frontend/src/pages/message/MessageComposePage.tsx
@@ -14,8 +14,8 @@ export default function MessageComposePage() {
   const receiverNickname = params.get('name');
 
   const [content, setContent] = useState('');
-  // TODO(slice 2): 보낸함(/messages) 생기면 성공 후 그쪽으로 이동. 현재는 홈 피드로.
-  const { submitting, send } = useSendMessage({ onSuccess: () => navigate('/posts') });
+  // 전송 성공 후 쪽지함(보낸함 탭에서 확인 가능)으로 이동.
+  const { submitting, send } = useSendMessage({ onSuccess: () => navigate('/messages') });
 
   // to가 누락/비숫자면 작성 불가 — 안내 + 빠져나갈 링크(PostDetailPage 404 가드 패턴).
   if (!to || isNaN(Number(to))) {

--- a/frontend/src/pages/message/MessageDetailPage.tsx
+++ b/frontend/src/pages/message/MessageDetailPage.tsx
@@ -1,0 +1,137 @@
+import { useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Trash2 } from 'lucide-react';
+import PageHeader from '../../components/common/PageHeader';
+import { fetchMessageDetail, deleteMessage } from '../../api/messages';
+import { useAuthStore } from '../../stores/useAuthStore';
+import type { MessageResponse } from '../../types/message';
+
+// 쪽지 전문 + 삭제. 수신자가 조회하면 백엔드가 자동 읽음 처리(스펙 Q2).
+// 안읽음 뱃지 -1 동기화는 store에 의존하므로 slice 3 범위. 여기서는 목록 캐시만 무효화한다.
+export default function MessageDetailPage() {
+  const { messageId } = useParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const myId = useAuthStore((s) => s.user?.id);
+
+  const id = Number(messageId);
+  const validId = messageId !== undefined && !isNaN(id);
+
+  const messageQuery = useQuery({
+    queryKey: ['messages', 'detail', id],
+    queryFn: () => fetchMessageDetail(id),
+    enabled: validId,
+  });
+  const message = messageQuery.data;
+
+  // 수신자가 안읽은 쪽지를 열면 백엔드가 read 처리하므로, 받은함 목록 캐시를 무효화해
+  // 복귀 시 read 상태가 반영되게 한다(뱃지 카운트 동기화는 slice 3).
+  useEffect(() => {
+    if (message && myId != null && message.receiverId === myId && !message.read) {
+      queryClient.invalidateQueries({ queryKey: ['messages', 'received'] });
+    }
+  }, [message, myId, queryClient]);
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteMessage(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['messages'] });
+      toast.success('쪽지를 삭제했어요.');
+      navigate('/messages');
+    },
+    onError: (err) => {
+      console.error('쪽지 삭제 실패:', err);
+      toast.error('쪽지를 삭제하지 못했습니다.');
+    },
+  });
+
+  function handleDelete() {
+    if (!confirm('이 쪽지를 삭제할까요?')) return;
+    deleteMutation.mutate();
+  }
+
+  // to가 비숫자/누락이면 작성 화면과 동일하게 가드(PostDetailPage 404 가드 패턴).
+  if (!validId) {
+    return (
+      <div>
+        <PageHeader title="쪽지" backTo="/messages" />
+        <div className="px-4 py-10 text-center">
+          <p className="text-sm text-gray-600">쪽지를 찾을 수 없어요.</p>
+          <Link to="/messages" className="mt-3 inline-block text-sm text-blue-600 underline">
+            쪽지함으로 돌아가기
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pb-20 md:pb-0">
+      <PageHeader
+        title="쪽지"
+        backTo="/messages"
+        rightAction={
+          message ? (
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+              aria-label="쪽지 삭제"
+              className="text-gray-400 hover:text-red-500 transition-colors disabled:opacity-40"
+            >
+              <Trash2 size={20} />
+            </button>
+          ) : undefined
+        }
+      />
+
+      <div className="max-w-2xl mx-auto px-4 py-6">
+        {messageQuery.isLoading ? (
+          <div className="py-12 text-center text-gray-400 text-sm">불러오는 중...</div>
+        ) : messageQuery.isError || !message ? (
+          <div className="py-12 text-center">
+            <p className="text-sm text-gray-600">쪽지를 불러오지 못했어요.</p>
+            <Link to="/messages" className="mt-3 inline-block text-sm text-blue-600 underline">
+              쪽지함으로 돌아가기
+            </Link>
+          </div>
+        ) : (
+          <MessageBody message={message} myId={myId} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MessageBody({ message, myId }: { message: MessageResponse; myId?: number }) {
+  const iAmSender = myId != null && message.senderId === myId;
+  // 내가 보낸 쪽지면 "받는 사람", 받은 쪽지면 "보낸 사람"을 상대방으로 표시.
+  const label = iAmSender ? '받는 사람' : '보낸 사람';
+  const counterpart = iAmSender ? message.receiverNickname : message.senderNickname;
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 pb-4 border-b border-gray-100">
+        <div className="flex-1 min-w-0">
+          <p className="text-xs text-gray-400">{label}</p>
+          <p className="text-sm font-semibold text-gray-900 truncate">{counterpart}</p>
+        </div>
+        {message.broadcast && (
+          <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+            공지
+          </span>
+        )}
+      </div>
+
+      <p className="mt-4 whitespace-pre-wrap break-words text-sm leading-relaxed text-gray-800">
+        {message.content}
+      </p>
+
+      <p className="mt-6 text-xs text-gray-400">
+        {new Date(message.createdAt).toLocaleString('ko-KR')}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/profile/ProfilePage.tsx
+++ b/frontend/src/pages/profile/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, Camera, Pencil, Search } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Camera, Pencil, Search, MessageCircle } from 'lucide-react';
 import { ProfileEditIcon } from '@/components/icons/ProfileEditIcon';
 import { Skeleton } from '@/components/shadcn-ui/skeleton';
 import PageHeader from '@/components/common/PageHeader';
@@ -163,6 +163,15 @@ export default function ProfilePage() {
         backTo="/posts"
         rightAction={
           <>
+            {/* 쪽지함 진입(돋보기 왼쪽). 안읽음 숫자 뱃지는 slice 3(store)에서 추가 */}
+            <button
+              type="button"
+              onClick={() => navigate('/messages')}
+              aria-label="쪽지함"
+              className="text-gray-900 hover:text-gray-600 transition-colors"
+            >
+              <MessageCircle size={24} />
+            </button>
             <Search size={24} className="text-gray-900" aria-hidden="true" />
             <button
               type="button"


### PR DESCRIPTION
## 개요
쪽지(DM) 기능 slice 2 — 쪽지함 목록/상세/삭제. 설계 스펙 `docs/superpowers/specs/2026-05-26-user-interaction-messaging-design.md` 6장 슬라이스 2.

slice 1(쪽지 보내기)은 PR #20으로 develop 머지 완료. 본 PR은 그 위에 쪽지함을 얹습니다.

## 변경 (논리 단위 6커밋)
- `api/messages.ts` — 받은함/보낸함/상세/삭제 4종 추가 (정답지: `api/notifications.ts`)
- `MessageBoxPage` (`/messages`) — 받은/보낸 2탭, 목록=React Query, Pagination. 받은함 unread 강조, broadcast "공지" 뱃지
- `MessageDetailPage` (`/messages/:messageId`) — 전문 조회 + 삭제(confirm). 수신자 조회 시 백엔드 자동 read 처리(Q2), 받은함 캐시 무효화로 복귀 시 read 반영
- `App.tsx` — `/messages`, `/messages/:messageId` 라우트 (`/messages/new`를 `:messageId`보다 먼저 배치)
- `ProfilePage` 헤더 — 돋보기 왼쪽 말풍선 아이콘 → `/messages`
- `MessageComposePage` — 모바일 전송 성공 후 `/posts` → `/messages` 교체

## 범위 제외(의도적)
- **안읽음 뱃지 / 읽음 -1 동기화**: `useMessageStore` 의존 → slice 3
- **알림 NEW_MESSAGE → 상세 라우팅 승격**: Q1(referenceId=messageId) 런타임 미확인 → `/messages` 목록 fallback 유지
- 답장/스레드: API 모델이 단발 메일함형이라 범위 밖

## 검증
- `tsc -b` 통과
- staging 실측: 프로필 말풍선 → 받은/보낸 탭 → 상세 → 삭제, 모바일 전송 후 쪽지함 이동 (리뷰 후 진행 예정)