### PR TITLE
feat(post-detail): 본문 평문 URL 클릭 가능한 링크로 변환

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -157,6 +157,12 @@
   font-weight: 700;
   margin-bottom: 0.5rem;
 }
+.post-content a {
+  color: #2563eb;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  overflow-wrap: anywhere;
+}
 .post-content strong {
   font-weight: 700;
 }

--- a/frontend/src/pages/post/PostDetailPage.tsx
+++ b/frontend/src/pages/post/PostDetailPage.tsx
@@ -40,6 +40,7 @@ import type { PostDetail, CommentResponse, PostImage } from '../../types/post';
 import { THERAPY_AREA_LABELS } from '../../constants/post';
 import { formatRelativeTime } from '../../utils/formatDate';
 import { resolveImageUrl } from '../../utils/resolveImageUrl';
+import { linkifyUrls } from '../../utils/linkify';
 import UserActionDropdown from '../../components/common/UserActionDropdown';
 import { useOpenMessageCompose } from '../../hooks/useOpenMessageCompose';
 import PageHeader from '@/components/common/PageHeader';
@@ -395,7 +396,10 @@ export default function PostDetailPage() {
             <div
               className="post-content"
               dangerouslySetInnerHTML={{
-                __html: DOMPurify.sanitize(post.content),
+                // 평문 URL을 <a>로 변환 후 정화. target은 새 탭(_blank) 유지를 위해 명시 허용.
+                __html: DOMPurify.sanitize(linkifyUrls(post.content), {
+                  ADD_ATTR: ['target'],
+                }),
               }}
             />
           ))}

--- a/frontend/src/utils/linkify.ts
+++ b/frontend/src/utils/linkify.ts
@@ -1,0 +1,42 @@
+// 게시글 본문의 평문 URL을 클릭 가능한 링크로 변환하는 어댑터.
+// 작성 에디터(SimpleTextEditor)는 평문 textarea라 본문에 <a>가 없고 URL도 그냥 글자다.
+// → 렌더 시점에 http(s) URL을 찾아 <a>로 감싼 HTML 문자열을 만든다.
+//   (저장 데이터는 평문 그대로 두어 기존 글까지 모두 적용되고 되돌리기 쉽다.)
+//
+// 평문을 HTML로 바꾸는 것이므로 URL이 아닌 조각은 반드시 escape해야 안전하다.
+// 위험 스킴(javascript: 등) 차단은 호출부의 DOMPurify.sanitize가 담당한다.
+//
+// 한계(의도적): 단순 정규식이라 URL 끝의 문장부호(`.`, `)`, `,` 등)까지 링크에
+// 포함될 수 있다. 일반 URL 공유엔 충분하며, 정교한 탐지가 필요하면 linkify 계열
+// 라이브러리 도입을 검토한다(트레이드오프: 새 의존성).
+
+const URL_RE = /https?:\/\/[^\s<]+/g;
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * 평문 본문에서 http(s) URL을 <a> 태그로 감싼 HTML 문자열을 반환한다.
+ * URL이 아닌 텍스트는 HTML escape하므로, 호출부에서 DOMPurify로 정화 후
+ * dangerouslySetInnerHTML에 그대로 주입할 수 있다.
+ */
+export function linkifyUrls(text: string): string {
+  let result = '';
+  let lastIndex = 0;
+  for (const match of text.matchAll(URL_RE)) {
+    const url = match[0];
+    const start = match.index ?? 0;
+    result += escapeHtml(text.slice(lastIndex, start));
+    const safeUrl = escapeHtml(url);
+    result += `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${safeUrl}</a>`;
+    lastIndex = start + url.length;
+  }
+  result += escapeHtml(text.slice(lastIndex));
+  return result;
+}


### PR DESCRIPTION
## 배경
게시글 상세페이지 본문은 평문 `<textarea>`(SimpleTextEditor)로 저장돼, 작성된 URL이 클릭되지 않는 글자로만 보였습니다.

## 변경
- `utils/linkify.ts` 신규 — 본문 평문에서 http(s) URL을 찾아 `<a target="_blank" rel="noopener noreferrer">`로 감싼 HTML 문자열 반환. URL이 아닌 조각은 HTML escape.
- `PostDetailPage.tsx` — 본문 렌더 시 `linkifyUrls()` 통과 후 기존 `DOMPurify.sanitize`로 정화(`ADD_ATTR: ['target']`로 새 탭 유지). 위험 스킴(`javascript:` 등) 차단은 DOMPurify가 그대로 담당.
- `index.css` — `.post-content a` 링크 스타일(파랑+밑줄) 추가.

## 설계 메모
- **렌더 시점 변환**: 저장 데이터는 평문 유지 → 기존 글 전부 적용되고 되돌리기 쉬움.
- **동작 변경(의도적)**: 평문을 HTML로 escape하므로, 기존엔 DOMPurify가 삼키던 본문 속 `<태그>` 글자가 이제 그대로 노출됩니다(평문 에디터 기준 더 올바른 동작).
- **범위**: 상세페이지 본문만. 피드 미리보기/ConcernCard는 미적용.
- **한계**: 단순 정규식이라 URL 끝 문장부호가 링크에 포함될 수 있음. 정교한 탐지 필요 시 linkify 계열 라이브러리 검토(새 의존성 트레이드오프).

## 검증
- `tsc -b` 통과
- linkify 출력 단위 검증: URL 래핑 / 다중 URL / 비URL escape / `javascript:` 비링크화 확인