### PR TITLE
feat(message): 쪽지 slice 3 — 안읽음 뱃지 + 읽음 동기화 + 실시간 SSE

### DIFF
--- a/frontend/src/api/messages.ts
+++ b/frontend/src/api/messages.ts
@@ -3,6 +3,7 @@ import type {
     MessageResponse,
     MessageSendRequest,
     PagedResponseMessageResponse,
+    UnreadCountResponse,
 } from '../types/message';
 
 export async function sendMessage(payload:MessageSendRequest): Promise<MessageResponse> {
@@ -36,4 +37,10 @@ export async function fetchMessageDetail(messageId: number): Promise<MessageResp
 
 export async function deleteMessage(messageId: number): Promise<void> {
     await axiosInstance.delete(`/messages/${messageId}`);
+}
+
+// 안읽은 쪽지 수. 뱃지 초기/탭복귀 동기화용. 정답지: api/notifications.ts fetchUnreadCount
+export async function fetchUnreadMessageCount(): Promise<UnreadCountResponse> {
+    const res = await axiosInstance.get('/me/messages/unread-count');
+    return res.data?.data ?? res.data;
 }

--- a/frontend/src/components/message/MessageUnreadBadge.tsx
+++ b/frontend/src/components/message/MessageUnreadBadge.tsx
@@ -1,0 +1,15 @@
+import { useMessageStore } from '../../stores/useMessageStore';
+
+// 안읽은 쪽지 수 빨간 숫자 뱃지. 0이면 렌더하지 않음.
+// absolute 포지셔닝이라 부모 요소가 relative여야 한다. 정답지: SideNav의 unreadCount 뱃지.
+export default function MessageUnreadBadge() {
+  const unreadCount = useMessageStore((s) => s.unreadCount);
+
+  if (unreadCount <= 0) return null;
+
+  return (
+    <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-red-500 text-white text-[10px] font-bold leading-none px-1">
+      {unreadCount > 99 ? '99+' : unreadCount}
+    </span>
+  );
+}

--- a/frontend/src/components/message/MessageUnreadBadge.tsx
+++ b/frontend/src/components/message/MessageUnreadBadge.tsx
@@ -1,14 +1,23 @@
 import { useMessageStore } from '../../stores/useMessageStore';
 
-// 안읽은 쪽지 수 빨간 숫자 뱃지. 0이면 렌더하지 않음.
+// 안읽은 쪽지 수 빨간 뱃지. 0이면 렌더하지 않음.
 // absolute 포지셔닝이라 부모 요소가 relative여야 한다. 정답지: SideNav의 unreadCount 뱃지.
-export default function MessageUnreadBadge() {
+// dotOnly=true(모바일): 화면이 좁아 숫자가 안 보이므로 작은 점만 표기.
+interface MessageUnreadBadgeProps {
+  dotOnly?: boolean;
+}
+
+export default function MessageUnreadBadge({ dotOnly = false }: MessageUnreadBadgeProps) {
   const unreadCount = useMessageStore((s) => s.unreadCount);
 
   if (unreadCount <= 0) return null;
 
+  if (dotOnly) {
+    return <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-red-500" />;
+  }
+
   return (
-    <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-red-500 text-white text-[10px] font-bold leading-none px-1">
+    <span className="absolute -top-1 -right-1 min-w-[15px] h-[15px] flex items-center justify-center rounded-full bg-red-500 text-white text-[9px] font-bold leading-none px-1">
       {unreadCount > 99 ? '99+' : unreadCount}
     </span>
   );

--- a/frontend/src/components/profile/ProfileHeaderActions.tsx
+++ b/frontend/src/components/profile/ProfileHeaderActions.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from '@/components/shadcn-ui/dropdown-menu';
+import MessageUnreadBadge from '@/components/message/MessageUnreadBadge';
 
 interface ProfileHeaderActionsProps {
   onEditProfile: () => void;
@@ -48,6 +49,8 @@ export default function ProfileHeaderActions({ onEditProfile }: ProfileHeaderAct
             >
               <Icon size={24} />
             </button>
+            {/* 쪽지함 아이콘에만 안읽음 뱃지(부모 relative). */}
+            {key === 'messages' && <MessageUnreadBadge />}
             <span className="pointer-events-none absolute left-1/2 top-full z-50 mt-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-gray-900 px-1.5 py-0.5 text-[11px] text-white opacity-0 transition-opacity group-hover:opacity-100">
               {label}
             </span>
@@ -57,7 +60,9 @@ export default function ProfileHeaderActions({ onEditProfile }: ProfileHeaderAct
 
       {/* 모바일: 케밥 → 드롭다운(아이콘 + 아래 라벨, 세로).
           modal=false: 드롭다운이 body 스크롤을 잠가 다른 모달로 누수되는 함정 회피(slice 1 전례). */}
-      <div className="flex md:hidden">
+      <div className="relative flex md:hidden">
+        {/* 쪽지함이 드롭다운 안에 숨으므로, 케밥 트리거에 안읽음 뱃지를 얹어 열기 전에 알린다. */}
+        <MessageUnreadBadge />
         <DropdownMenu modal={false}>
           <DropdownMenuTrigger aria-label="메뉴" className="text-gray-900">
             <MoreVertical size={24} />

--- a/frontend/src/components/profile/ProfileHeaderActions.tsx
+++ b/frontend/src/components/profile/ProfileHeaderActions.tsx
@@ -61,8 +61,9 @@ export default function ProfileHeaderActions({ onEditProfile }: ProfileHeaderAct
       {/* 모바일: 케밥 → 드롭다운(아이콘 + 아래 라벨, 세로).
           modal=false: 드롭다운이 body 스크롤을 잠가 다른 모달로 누수되는 함정 회피(slice 1 전례). */}
       <div className="relative flex md:hidden">
-        {/* 쪽지함이 드롭다운 안에 숨으므로, 케밥 트리거에 안읽음 뱃지를 얹어 열기 전에 알린다. */}
-        <MessageUnreadBadge />
+        {/* 쪽지함이 드롭다운 안에 숨으므로, 케밥 트리거에 안읽음 뱃지를 얹어 열기 전에 알린다.
+            모바일은 화면이 좁아 숫자 대신 작은 점만(dotOnly). */}
+        <MessageUnreadBadge dotOnly />
         <DropdownMenu modal={false}>
           <DropdownMenuTrigger aria-label="메뉴" className="text-gray-900">
             <MoreVertical size={24} />
@@ -76,7 +77,11 @@ export default function ProfileHeaderActions({ onEditProfile }: ProfileHeaderAct
               >
                 {/* size prop이 아니라 size- 클래스로 지정 — DropdownMenuItem의
                     `[&_svg:not([class*='size-'])]:size-4` 강제 규칙을 벗어나기 위함(size-10=40px) */}
-                <Icon className="size-6" />
+                <span className="relative flex">
+                  <Icon className="size-6" />
+                  {/* 메뉴를 열면 쪽지함 아이콘에도 안읽음 점을 표기(부모 relative). */}
+                  {key === 'messages' && <MessageUnreadBadge dotOnly />}
+                </span>
                 <span className="text-[11px] text-gray-600">{label}</span>
               </DropdownMenuItem>
             ))}

--- a/frontend/src/hooks/useNotificationSSE.ts
+++ b/frontend/src/hooks/useNotificationSSE.ts
@@ -2,7 +2,9 @@ import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 import { useAuthStore } from '../stores/useAuthStore';
 import { useNotificationStore } from '../stores/useNotificationStore';
+import { useMessageStore } from '../stores/useMessageStore';
 import { fetchUnreadCount } from '../api/notifications';
+import { fetchUnreadMessageCount } from '../api/messages';
 import { connectSSE, type SseConnection } from '../lib/sseClient';
 import type { NotificationResponse } from '../types/notification';
 
@@ -35,12 +37,14 @@ export function useNotificationSSE() {
     const accessToken = tokens?.accessToken;
     if (!accessToken) {
       store.getState().clear();
+      useMessageStore.getState().clear();
       return;
     }
 
     // MSW 모드에서는 SSE 비활성화, unreadCount만 REST로 조회
     if (import.meta.env.VITE_MSW_ENABLED === 'true') {
       syncUnreadCount(accessToken);
+      syncMessageUnreadCount();
       return;
     }
 
@@ -49,6 +53,7 @@ export function useNotificationSSE() {
 
     // 초기 unreadCount 동기화
     syncUnreadCount(accessToken);
+    syncMessageUnreadCount();
 
     // SSE 연결
     connect(accessToken);
@@ -57,6 +62,7 @@ export function useNotificationSSE() {
     const handleVisibility = () => {
       if (document.visibilityState === 'visible' && isActiveRef.current) {
         syncUnreadCount(accessToken);
+        syncMessageUnreadCount();
         if (!store.getState().isConnected) {
           connect(accessToken);
         }
@@ -101,6 +107,11 @@ export function useNotificationSSE() {
           try {
             const notification = JSON.parse(event.data) as NotificationResponse;
             store.getState().addNotification(notification);
+            // 쪽지 도착이면 쪽지 전용 뱃지도 +1(알림 뱃지는 위 addNotification이 이미 +1).
+            // 둘 다 오르는 건 의도된 동작 — 스펙 "알림/뱃지 동작" 참조.
+            if (notification.type === 'NEW_MESSAGE') {
+              useMessageStore.getState().increment();
+            }
             toast(notification.content, { duration: 4000 });
           } catch (err) {
             console.warn('알림 이벤트 파싱 실패:', err);
@@ -146,6 +157,16 @@ export function useNotificationSSE() {
     } catch (err) {
       // 401은 axios 인터셉터가 refresh로 흡수합니다. 그 외 일시 장애는 토스트 없이 로깅만 합니다.
       console.warn('unreadCount 동기화 실패:', err);
+    }
+  }
+
+  // 안읽은 쪽지 수 동기화(신뢰 소스). SSE 끊긴 동안 도착한 쪽지를 초기/탭복귀 시점에 반영.
+  async function syncMessageUnreadCount() {
+    try {
+      const { count } = await fetchUnreadMessageCount();
+      useMessageStore.getState().setUnreadCount(count);
+    } catch (err) {
+      console.warn('쪽지 unreadCount 동기화 실패:', err);
     }
   }
 }

--- a/frontend/src/hooks/useNotificationSSE.ts
+++ b/frontend/src/hooks/useNotificationSSE.ts
@@ -163,8 +163,8 @@ export function useNotificationSSE() {
   // 안읽은 쪽지 수 동기화(신뢰 소스). SSE 끊긴 동안 도착한 쪽지를 초기/탭복귀 시점에 반영.
   async function syncMessageUnreadCount() {
     try {
-      const { count } = await fetchUnreadMessageCount();
-      useMessageStore.getState().setUnreadCount(count);
+      const { unreadCount } = await fetchUnreadMessageCount();
+      useMessageStore.getState().setUnreadCount(unreadCount);
     } catch (err) {
       console.warn('쪽지 unreadCount 동기화 실패:', err);
     }

--- a/frontend/src/pages/message/MessageDetailPage.tsx
+++ b/frontend/src/pages/message/MessageDetailPage.tsx
@@ -6,10 +6,10 @@ import { Trash2 } from 'lucide-react';
 import PageHeader from '../../components/common/PageHeader';
 import { fetchMessageDetail, deleteMessage } from '../../api/messages';
 import { useAuthStore } from '../../stores/useAuthStore';
+import { useMessageStore } from '../../stores/useMessageStore';
 import type { MessageResponse } from '../../types/message';
 
 // 쪽지 전문 + 삭제. 수신자가 조회하면 백엔드가 자동 읽음 처리(스펙 Q2).
-// 안읽음 뱃지 -1 동기화는 store에 의존하므로 slice 3 범위. 여기서는 목록 캐시만 무효화한다.
 export default function MessageDetailPage() {
   const { messageId } = useParams();
   const navigate = useNavigate();
@@ -27,10 +27,12 @@ export default function MessageDetailPage() {
   const message = messageQuery.data;
 
   // 수신자가 안읽은 쪽지를 열면 백엔드가 read 처리하므로, 받은함 목록 캐시를 무효화해
-  // 복귀 시 read 상태가 반영되게 한다(뱃지 카운트 동기화는 slice 3).
+  // 복귀 시 read 상태가 반영되게 하고, 안읽음 뱃지를 낙관적으로 1 줄인다.
+  // 낙관 감소는 표시 지연을 줄이는 보조 수단 — 신뢰 소스는 초기/탭복귀 동기화다.
   useEffect(() => {
     if (message && myId != null && message.receiverId === myId && !message.read) {
       queryClient.invalidateQueries({ queryKey: ['messages', 'received'] });
+      useMessageStore.getState().decrement();
     }
   }, [message, myId, queryClient]);
 

--- a/frontend/src/stores/useMessageStore.ts
+++ b/frontend/src/stores/useMessageStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+// 안읽은 쪽지 수 전용 store(push).
+// 쪽지함 목록은 React Query(pull), 안읽음 카운트는 store(push)로 이원화한다 — 알림 시스템과 동일.
+// useNotificationStore의 unreadCount 부분만 거울 복제.
+interface MessageState {
+  unreadCount: number;
+
+  setUnreadCount: (count: number) => void;
+  increment: () => void;
+  decrement: () => void;
+  clear: () => void;
+}
+
+export const useMessageStore = create<MessageState>((set) => ({
+  unreadCount: 0,
+
+  // 초기/탭복귀 시 서버값으로 덮어쓰기(신뢰 소스).
+  setUnreadCount: (count) => set({ unreadCount: count }),
+
+  // SSE로 NEW_MESSAGE 도착 시 +1.
+  increment: () => set((state) => ({ unreadCount: state.unreadCount + 1 })),
+
+  // 안읽은 쪽지 열람 성공 시 낙관적 -1(0 밑으로는 안 내려감).
+  decrement: () => set((state) => ({ unreadCount: Math.max(0, state.unreadCount - 1) })),
+
+  clear: () => set({ unreadCount: 0 }),
+}));

--- a/frontend/src/types/message.ts
+++ b/frontend/src/types/message.ts
@@ -25,5 +25,5 @@ export interface PagedResponseMessageResponse{
 }
 
 export interface UnreadCountResponse {
-    count: number;
+    unreadCount: number;
 }


### PR DESCRIPTION
## 개요
쪽지(DM) slice 3. 안읽은 쪽지 수 뱃지 + 읽음 시 -1 동기화 + 실시간 갱신. 알림 시스템을 거울 복제하되 별도 SSE 연결 없이 기존 알림 SSE 1개에 편승한다.

## 논리 커밋 4개
1. **데이터층** — `useMessageStore`(unreadCount 전용, set/increment/decrement/clear) + `fetchUnreadMessageCount()`. 뱃지=store(push)/목록=RQ(pull) 이원화.
2. **뱃지** — `MessageUnreadBadge`(store 구독, 0이면 미렌더). 프로필 헤더 PC 아이콘 / 모바일 케밥에 배선.
3. **SSE 편승** — `useNotificationSSE`에 초기·MSW·탭복귀 `/me/messages/unread-count` 동기화 추가, `notification` 이벤트가 `NEW_MESSAGE`면 `increment()`, 로그아웃 시 `clear()`.
4. **읽음 -1** — `MessageDetailPage` 읽음 effect에 낙관적 `decrement()`. 신뢰 소스는 동기화.

## 설계 근거
- 쪽지는 알림으로도 쌓이므로 도착 시 알림 뱃지·쪽지 뱃지 둘 다 +1 — 의도된 동작(SSE 특수처리 불필요).
- 낙관 감소는 표시 지연을 줄이는 보조 수단. GET 상세가 read 처리 안 했거나 실패해도 다음 초기/탭복귀 동기화가 서버값으로 되돌린다.
- 백엔드 의존 Q2(GET 상세=수신자 자동 읽음) 해소 확인됨.

## 범위 제외
- 알림 NEW_MESSAGE 상세 라우팅 승격(Q1 referenceId=messageId 런타임 미확인) → `/messages` 목록 fallback 유지.
- 뱃지 전역 노출(현재 진입점이 프로필 헤더 1곳) → 별도 작업.

## 검증
- `tsc -b` 통과.
- staging SSE 실측은 리뷰/머지 과정에서 진행 예정(다른 계정 발송→실시간 +1, 읽음→-1).

⚠️ Speed mode AI 작성 — per-commit 자가 리뷰 대상.