### PR TITLE
feat(landing): 랜딩 페이지 부활 (Mellti)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import Layout from './components/layout/Layout';
-import RootRedirect from './components/auth/RootRedirect';
+import LandingPage from './pages/landing/LandingPage';
 import GuestRoute from './components/auth/GuestRoute';
 import AuthRoute from './components/auth/AuthRoute';
 import LoginPage from './pages/auth/LoginPage';
@@ -49,7 +49,9 @@ function App() {
       <AnalyticsTracker />
       <NotificationManager />
       <Routes>
-        <Route path="/" element={<RootRedirect />} />
+        {/* `/`는 로그인 여부와 무관하게 누구에게나 랜딩 페이지를 노출(2026-06-06 부활).
+        로그인 유저는 랜딩 nav의 "커뮤니티" 링크로 /posts 이동. */}
+        <Route path="/" element={<LandingPage />} />
         {/* 정책 페이지 — 비로그인/로그인 모두 접근, Layout 밖 독립 렌더 */}
         <Route path="/privacy" element={<PrivacyPage />} />
         <Route path="/terms" element={<TermsPage />} />

--- a/frontend/src/components/auth/RootRedirect.tsx
+++ b/frontend/src/components/auth/RootRedirect.tsx
@@ -1,8 +1,0 @@
-import { Navigate } from 'react-router-dom';
-import { useAuthStore } from '../../stores/useAuthStore';
-
-export default function RootRedirect() {
-  const user = useAuthStore((s) => s.user);
-
-  return <Navigate to={user ? '/posts' : '/signup'} replace />;
-}

--- a/frontend/src/components/post/PostCard.tsx
+++ b/frontend/src/components/post/PostCard.tsx
@@ -4,7 +4,6 @@ import { Bookmark, MessageCircle, Heart, Lock } from 'lucide-react';
 import type { PostSummary, PostReaction } from '../../types/post';
 import { formatRelativeTime } from '../../utils/formatDate';
 import { scrapPost, unscrapPost } from '../../api/posts';
-import VerifiedBadge from './VerifiedBadge';
 import { useReactionToggle } from '../../hooks/useReactionToggle';
 import { useDragScroll } from '../../hooks/useDragScroll';
 import UserAvatar from '../common/UserAvatar';
@@ -91,7 +90,6 @@ export default function PostCard({ post, onReactionUpdated }: PostCardProps) {
             size="xs"
           />
           <span className="text-sm font-medium text-neutral-950">{post.authorNickname}</span>
-          <VerifiedBadge status={post.authorVerificationStatus} />
           <span className="text-[11px] text-gray-500">{formatRelativeTime(post.createdAt)}</span>
           <button
             type="button"

--- a/frontend/src/hooks/useScrollReveal.ts
+++ b/frontend/src/hooks/useScrollReveal.ts
@@ -1,0 +1,40 @@
+import { useLayoutEffect } from 'react';
+import type { RefObject } from 'react';
+
+/**
+ * 컨테이너 안의 [data-animate] 요소를 스크롤 진입 시 페이드+슬라이드로 등장시킨다.
+ *
+ * progressive enhancement:
+ * - 마크업에는 숨김 클래스를 넣지 않는다 → JS 비활성/검색봇/prerender는 콘텐츠를 그대로 본다(SEO 보호).
+ * - JS가 동작할 때만 useLayoutEffect(paint 직전)에서 숨김 상태를 입혀 깜빡임 없이 시작한다.
+ * - IntersectionObserver로 뷰포트 진입 시 1회 노출하고 관찰을 해제한다.
+ */
+export function useScrollReveal(containerRef: RefObject<HTMLElement | null>) {
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container || typeof IntersectionObserver === 'undefined') return;
+
+    const els = Array.from(container.querySelectorAll<HTMLElement>('[data-animate]'));
+
+    // 숨김 + 트랜지션 준비 (JS가 있을 때만 적용되므로 no-JS/봇은 영향 없음).
+    els.forEach((el) => {
+      el.classList.add('opacity-0', 'translate-y-6', 'transition-all', 'duration-700', 'ease-out');
+    });
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          const el = entry.target as HTMLElement;
+          el.classList.remove('opacity-0', 'translate-y-6');
+          observer.unobserve(el);
+        });
+      },
+      { threshold: 0.15 },
+    );
+
+    els.forEach((el) => observer.observe(el));
+
+    return () => observer.disconnect();
+  }, [containerRef]);
+}

--- a/frontend/src/hooks/useScrollReveal.ts
+++ b/frontend/src/hooks/useScrollReveal.ts
@@ -1,5 +1,9 @@
-import { useLayoutEffect } from 'react';
+import { useEffect, useLayoutEffect } from 'react';
 import type { RefObject } from 'react';
+
+// SSR(prerender renderToString)에서는 useLayoutEffect가 경고를 내므로 useEffect로 대체.
+// 클라이언트에서는 paint 직전 실행이 필요(깜빡임 방지)하므로 useLayoutEffect 유지.
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 /**
  * 컨테이너 안의 [data-animate] 요소를 스크롤 진입 시 페이드+슬라이드로 등장시킨다.
@@ -10,7 +14,7 @@ import type { RefObject } from 'react';
  * - IntersectionObserver로 뷰포트 진입 시 1회 노출하고 관찰을 해제한다.
  */
 export function useScrollReveal(containerRef: RefObject<HTMLElement | null>) {
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const container = containerRef.current;
     if (!container || typeof IntersectionObserver === 'undefined') return;
 

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -135,7 +135,7 @@ export default function LandingPage() {
                     </span>
                   </div>
                   {/* 필터 칩 */}
-                  <div className="mb-2.5 flex gap-[5px] overflow-hidden">
+                  <div className="mb-2.5 flex gap-[5px] overflow-hidden border-b border-neutral-200 pb-2.5">
                     <span className="whitespace-nowrap rounded-full border border-neutral-900 bg-neutral-900 px-2.5 py-1 text-[0.6rem] font-medium text-white">
                       전체
                     </span>
@@ -149,7 +149,7 @@ export default function LandingPage() {
                     ))}
                   </div>
                   {/* 정렬 */}
-                  <div className="mb-3 flex gap-2.5 text-[0.62rem] text-neutral-400">
+                  <div className="mb-3 flex gap-2.5 border-b border-neutral-200 pb-2.5 text-[0.62rem] text-neutral-400">
                     <span className="rounded-full bg-neutral-100 px-2 py-[3px] font-semibold text-neutral-900">
                       최신순
                     </span>
@@ -161,7 +161,18 @@ export default function LandingPage() {
                       <div className="h-7 w-7 rounded-full bg-neutral-300" />
                       <span className="font-semibold text-neutral-900">숨이는 귀엽다</span>
                       <span className="text-[0.6rem] text-neutral-400">1분 전</span>
-                      <span className="ml-auto text-[0.8rem] text-neutral-300">☐</span>
+                      <svg
+                        className="ml-auto h-3.5 w-3.5 text-neutral-300"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden
+                      >
+                        <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z" />
+                      </svg>
                     </div>
                     <div className="mb-2 rounded-xl border border-neutral-200 bg-neutral-50 p-3">
                       <div className="mb-2.5 text-[0.72rem] font-bold text-neutral-700">❓ 고민카드</div>
@@ -193,7 +204,18 @@ export default function LandingPage() {
                       <div className="h-7 w-7 rounded-full bg-neutral-400" />
                       <span className="font-semibold text-neutral-900">햄스터#2727</span>
                       <span className="text-[0.6rem] text-neutral-400">8시간 전</span>
-                      <span className="ml-auto text-[0.8rem] text-neutral-300">☐</span>
+                      <svg
+                        className="ml-auto h-3.5 w-3.5 text-neutral-300"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden
+                      >
+                        <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z" />
+                      </svg>
                     </div>
                     <p className="mb-2 text-[0.7rem] leading-relaxed text-neutral-600">
                       🚩 각 사이트별 최신 채용 공고 모음입니다!

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { ArrowLeft, Upload } from 'lucide-react';
+import { ArrowLeft, Upload, PencilLine, LockOpen } from 'lucide-react';
 import { useAuthStore } from '../../stores/useAuthStore';
 
 /**
@@ -328,8 +328,145 @@ export default function LandingPage() {
           </div>
         </section>
 
-        {/* Phase 5: Feature ② 고민카드 */}
-        <section id="feature-worry" className="p-10">[feature-worry]</section>
+        {/* Feature ② 고민카드 — 좌: 텍스트, 우: 실제 고민카드 작성 폼. bg-secondary. 900px↓ 1열(텍스트 먼저). */}
+        <section
+          id="feature-worry"
+          className="relative bg-neutral-50 px-6 py-[120px] max-[480px]:px-5 max-[480px]:py-20"
+        >
+          <div className="mx-auto grid max-w-[1100px] grid-cols-2 items-center gap-20 max-[900px]:grid-cols-1 max-[900px]:gap-12">
+            {/* 좌: 텍스트 */}
+            <div data-animate>
+              <span className="mb-4 inline-block rounded-full border border-neutral-200 bg-neutral-100 px-3.5 py-[5px] text-[0.8rem] font-semibold text-neutral-500">
+                임상 고민 해결
+              </span>
+              <h2 className="mb-4 text-[clamp(1.6rem,3vw,2.3rem)] font-extrabold leading-[1.35] tracking-[-0.5px] text-neutral-900">
+                혼자 고민하던 치료,
+                <br />
+                <span className="font-extrabold">이제 그만</span>
+              </h2>
+              <p className="mb-8 text-base leading-[1.8] text-neutral-500">
+                고민카드를 작성하면 동료 치료사들의 경험과 노하우를 얻을 수 있어요. 연령대, 진단명,
+                치료영역별로 구조화된 폼으로 정확한 도움을 받아보세요.
+              </p>
+              <ul className="flex flex-col gap-5">
+                {[
+                  ['🧩', '구조화된 고민카드', '연령대, 진단명, 치료영역을 포함한 체계적인 작성 폼'],
+                  ['💡', '동료의 실전 경험', '댓글과 리액션으로 다양한 중재 전략을 공유'],
+                  ['📌', '스크랩 & 아카이빙', '유용한 게시글은 스크랩하여 마이페이지에서 보관'],
+                ].map(([icon, title, desc]) => (
+                  <li key={title} className="flex items-start gap-3.5">
+                    <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-neutral-200 bg-neutral-50 text-[1.2rem]">
+                      {icon}
+                    </span>
+                    <div>
+                      <strong className="mb-0.5 block text-[0.95rem] font-semibold">{title}</strong>
+                      <p className="text-[0.85rem] leading-[1.5] text-neutral-500">{desc}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* 우: 실제 ConcernForm 화면 축소 재현 (순서: 연령대→치료영역→진단명→고민지점) */}
+            <div data-animate className="flex justify-center">
+              <div className="w-[300px] rounded-[28px] border border-neutral-200 bg-white p-2.5 shadow-[0_16px_48px_rgba(0,0,0,0.12)] max-[900px]:w-[260px]">
+                <div className="mx-auto mb-2.5 mt-1 h-[5px] w-20 rounded-[10px] bg-neutral-200" />
+                <div className="min-h-[460px] overflow-hidden rounded-[20px] border border-[#eeeeee] bg-white p-3.5">
+                  {/* 헤더 — ← [일반 글 | 고민 카드] ✏️ */}
+                  <div className="mb-3 flex items-center justify-between border-b border-neutral-100 pb-2">
+                    <ArrowLeft size={12} className="text-neutral-700" />
+                    <div className="inline-flex rounded-lg bg-neutral-100 p-0.5 text-[0.5rem]">
+                      <span className="rounded-md px-2 py-1 text-neutral-500">일반 글</span>
+                      <span className="rounded-md bg-white px-2 py-1 font-semibold text-neutral-900 shadow-sm">
+                        고민 카드
+                      </span>
+                    </div>
+                    <PencilLine size={12} className="text-neutral-900" />
+                  </div>
+                  <div className="flex flex-col gap-3">
+                    {/* 연령대 */}
+                    <div>
+                      <div className="mb-1 text-[0.6rem] font-semibold text-neutral-800">연령대</div>
+                      <div className="flex flex-wrap gap-1">
+                        {['영아기', '유아기', '아동기', '청소년기', '성년기', '노령기'].map((c) => (
+                          <span
+                            key={c}
+                            className={`rounded-full border px-2 py-0.5 text-[0.52rem] font-medium ${
+                              c === '유아기'
+                                ? 'border-neutral-900 bg-neutral-900 text-white'
+                                : 'border-neutral-200 bg-white text-neutral-700'
+                            }`}
+                          >
+                            {c}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                    {/* 치료영역 */}
+                    <div>
+                      <div className="mb-1 text-[0.6rem] font-semibold text-neutral-800">치료영역</div>
+                      <div className="flex flex-wrap gap-1">
+                        {[
+                          '감각통합',
+                          '언어치료',
+                          '작업치료',
+                          '인지치료',
+                          '물리치료',
+                          '미술치료',
+                          '음악치료',
+                          '놀이치료',
+                          '행동치료',
+                        ].map((c) => (
+                          <span
+                            key={c}
+                            className={`rounded-full border px-2 py-0.5 text-[0.52rem] font-medium ${
+                              c === '감각통합'
+                                ? 'border-neutral-900 bg-neutral-900 text-white'
+                                : 'border-neutral-200 bg-white text-neutral-700'
+                            }`}
+                          >
+                            {c}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                    {/* 진단명 */}
+                    <div>
+                      <div className="mb-1 text-[0.6rem] font-semibold text-neutral-800">진단명</div>
+                      <div className="mb-1 flex flex-wrap gap-1">
+                        <span className="inline-flex items-center gap-1 rounded-full bg-neutral-100 px-2 py-0.5 text-[0.52rem] text-neutral-800">
+                          자폐스펙트럼장애 <span className="text-neutral-500">×</span>
+                        </span>
+                      </div>
+                      <div className="rounded-md border border-neutral-200 px-2 py-1.5 text-[0.55rem] text-neutral-400">
+                        진단명을 입력하세요
+                      </div>
+                    </div>
+                    {/* 고민지점 */}
+                    <div>
+                      <div className="mb-1 text-[0.6rem] font-semibold text-neutral-800">고민지점</div>
+                      <div className="min-h-[44px] rounded-md border border-neutral-200 px-2 py-1.5 text-[0.55rem] leading-relaxed text-neutral-600">
+                        만 3세 asd 아동 조절 잡기 어려워서 글 씁니다. 넓은 곳 달리기만 하고 치료실 내에서
+                        소리를 지르거나…
+                      </div>
+                      <p className="mt-0.5 text-right text-[0.5rem] text-neutral-400">52 / 2000</p>
+                    </div>
+                  </div>
+                  {/* 푸터 — 공개범위 + 작성 완료 */}
+                  <div className="mt-3 flex items-center border-t border-neutral-100 pt-2">
+                    <span className="flex items-center gap-1 text-[0.55rem] text-neutral-700">
+                      전체 공개 <LockOpen size={10} />
+                    </span>
+                    <div className="flex-1" />
+                    <span className="rounded-md border border-neutral-900 bg-neutral-900 px-3 py-1 text-[0.55rem] font-semibold text-white">
+                      작성 완료
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
 
         {/* Phase 6: Feature ③ 커뮤니티 기능 */}
         <section id="feature-community" className="p-10">[feature-community]</section>

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -1,6 +1,8 @@
+import { useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowLeft, Upload, PencilLine, LockOpen } from 'lucide-react';
 import { useAuthStore } from '../../stores/useAuthStore';
+import { useScrollReveal } from '../../hooks/useScrollReveal';
 
 /**
  * Mellti 랜딩 페이지 (비로그인 진입 화면).
@@ -14,9 +16,11 @@ import { useAuthStore } from '../../stores/useAuthStore';
  */
 export default function LandingPage() {
   const user = useAuthStore((s) => s.user);
+  const rootRef = useRef<HTMLDivElement>(null);
+  useScrollReveal(rootRef);
 
   return (
-    <div className="min-h-screen bg-white font-sans text-neutral-900">
+    <div ref={rootRef} className="min-h-screen bg-white font-sans text-neutral-900">
       {/* 상단 고정 네비게이션 (반투명 + blur). 높이 64px = h-16. */}
       <nav
         id="nav"

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 import { Link } from 'react-router-dom';
-import { ArrowLeft, Upload, PencilLine, LockOpen } from 'lucide-react';
+import { ArrowLeft, Upload, PencilLine, LockOpen, MessageCircle, Heart } from 'lucide-react';
 import { useAuthStore } from '../../stores/useAuthStore';
 import { useScrollReveal } from '../../hooks/useScrollReveal';
 
@@ -142,7 +142,7 @@ export default function LandingPage() {
                     {['감각통합', '언어치료', '작업치료'].map((c) => (
                       <span
                         key={c}
-                        className="whitespace-nowrap rounded-full border border-neutral-300 bg-white px-2.5 py-1 text-[0.6rem] font-medium text-neutral-600"
+                        className="whitespace-nowrap rounded-full border border-neutral-300 bg-white px-2.5 py-1 text-[0.6rem] font-medium text-neutral-950"
                       >
                         {c}
                       </span>
@@ -150,10 +150,12 @@ export default function LandingPage() {
                   </div>
                   {/* 정렬 */}
                   <div className="mb-3 flex gap-2.5 border-b border-neutral-200 pb-2.5 text-[0.62rem] text-neutral-400">
-                    <span className="rounded-full bg-neutral-100 px-2 py-[3px] font-semibold text-neutral-900">
+                    <span className="rounded-full border border-neutral-900 bg-neutral-900 px-2 py-[3px] font-medium text-white">
                       최신순
                     </span>
-                    <span>인기순</span>
+                    <span className="rounded-full border border-neutral-300 px-2 py-[3px] text-neutral-500">
+                      인기순
+                    </span>
                   </div>
                   {/* 고민카드 글 */}
                   <div className="border-b border-[#eeeeee] py-3">
@@ -174,28 +176,44 @@ export default function LandingPage() {
                         <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z" />
                       </svg>
                     </div>
-                    <div className="mb-2 rounded-xl border border-neutral-200 bg-neutral-50 p-3">
-                      <div className="mb-2.5 text-[0.72rem] font-bold text-neutral-700">❓ 고민카드</div>
-                      <div className="mb-2.5">
-                        {[
-                          ['연령대', '유아기'],
-                          ['치료영역', '감각통합'],
-                          ['진단명', '자폐스펙트럼장애'],
-                        ].map(([label, value]) => (
-                          <div key={label} className="flex gap-2.5 py-[3px] text-[0.62rem]">
-                            <span className="min-w-[46px] font-semibold text-neutral-500">{label}</span>
-                            <span className="text-neutral-700">{value}</span>
-                          </div>
-                        ))}
+                    <div className="mb-2 overflow-hidden rounded-xl border border-neutral-200">
+                      {/* 헤더바 — 실제 ConcernCard와 동일(회색 바 + 원형 ? 뱃지) */}
+                      <div className="flex items-center gap-1.5 border-b border-neutral-100 bg-neutral-50 px-3 py-2">
+                        <span className="flex h-4 w-4 items-center justify-center rounded-full bg-neutral-800 text-[0.5rem] text-white">
+                          ?
+                        </span>
+                        <span className="text-[0.72rem] font-bold text-neutral-700">고민카드</span>
                       </div>
-                      <div className="border-t border-neutral-200 pt-2 text-[0.65rem] leading-relaxed text-neutral-600">
-                        <div className="mb-1 font-bold text-neutral-700">고민지점</div>
-                        만 3세 asd 아동 조절 잡기 어려워서 글 씁니다
+                      <div className="px-3 py-2.5">
+                        <div className="mb-2.5">
+                          {[
+                            ['연령대', '유아기'],
+                            ['치료영역', '감각통합'],
+                          ].map(([label, value]) => (
+                            <div key={label} className="flex gap-2.5 py-[3px] text-[0.62rem]">
+                              <span className="min-w-[46px] font-semibold text-neutral-500">{label}</span>
+                              <span className="text-neutral-700">{value}</span>
+                            </div>
+                          ))}
+                          {/* 진단명 — 실제처럼 칩(pill)로 */}
+                          <div className="flex gap-2.5 py-[3px] text-[0.62rem]">
+                            <span className="min-w-[46px] font-semibold text-neutral-500">진단명</span>
+                            <span className="rounded-full bg-neutral-100 px-2 py-0.5 text-neutral-700">
+                              자폐스펙트럼장애
+                            </span>
+                          </div>
+                        </div>
+                        <div className="border-t border-neutral-100 pt-2 text-[0.65rem] leading-relaxed text-neutral-600">
+                          <div className="mb-1 font-bold text-neutral-700">고민지점</div>
+                          만 3세 asd 아동 조절 잡기 어려워서 글 씁니다
+                        </div>
                       </div>
                     </div>
-                    <div className="flex gap-3.5 text-[0.65rem] text-neutral-400">
-                      <span>💬 0</span>
-                      <span>♡</span>
+                    <div className="flex items-center gap-3 text-[0.65rem] text-neutral-400">
+                      <span className="flex items-center gap-1 font-medium text-neutral-500">
+                        <MessageCircle size={12} />0
+                      </span>
+                      <Heart size={13} />
                     </div>
                   </div>
                   {/* 일반 글 */}
@@ -220,9 +238,11 @@ export default function LandingPage() {
                     <p className="mb-2 text-[0.7rem] leading-relaxed text-neutral-600">
                       🚩 각 사이트별 최신 채용 공고 모음입니다!
                     </p>
-                    <div className="flex gap-3.5 text-[0.65rem] text-neutral-400">
-                      <span>💬 0</span>
-                      <span>♡</span>
+                    <div className="flex items-center gap-3 text-[0.65rem] text-neutral-400">
+                      <span className="flex items-center gap-1 font-medium text-neutral-500">
+                        <MessageCircle size={12} />0
+                      </span>
+                      <Heart size={13} />
                     </div>
                   </div>
                 </div>

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -53,8 +53,156 @@ export default function LandingPage() {
       </nav>
 
       <main>
-        {/* Phase 3: Hero (폰 목업 포함) */}
-        <section id="hero" className="p-10">[hero]</section>
+        {/* Hero — 좌측 카피/CTA + 우측 폰 목업. 900px↓ 1열 스택. */}
+        <section
+          id="hero"
+          className="relative flex min-h-screen items-center overflow-hidden bg-white px-6 pb-[100px] pt-[124px] max-[480px]:pb-[60px] max-[480px]:pt-[94px]"
+        >
+          {/* 우측 상단 방향 은은한 radial 배경 (gray-100 → transparent) */}
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_70%_50%,#f5f5f5_0%,transparent_60%)]" />
+
+          <div className="relative z-10 mx-auto grid w-full max-w-[1200px] grid-cols-2 items-center gap-[60px] max-[900px]:grid-cols-1 max-[900px]:gap-10 max-[900px]:text-center">
+            {/* 좌측: 카피 + CTA */}
+            <div>
+              <p
+                data-animate
+                className="mb-5 inline-block rounded-full border border-neutral-200 bg-neutral-100 px-4 py-1.5 text-[0.85rem] font-medium text-neutral-500"
+              >
+                치료사 전용 커뮤니티
+              </p>
+              <h1
+                data-animate
+                className="mb-4 text-[clamp(2rem,4vw,3rem)] font-extrabold leading-[1.35] tracking-[-1px] text-neutral-900 max-[480px]:text-[1.65rem]"
+              >
+                아동발달재활 선생님들의
+                <br />
+                <span className="font-extrabold">모든 임상고민</span>이 여기에
+              </h1>
+              <p data-animate className="mb-7 text-[1.15rem] text-neutral-500">
+                치료사들의 성장 바다, <strong className="font-bold text-neutral-900">Mellti</strong>
+              </p>
+              <div
+                data-animate
+                className="mb-9 flex flex-wrap gap-2.5 max-[900px]:justify-center"
+              >
+                {['💬 임상 고민', '📚 보수교육 정보', '💼 구직 정보'].map((t) => (
+                  <span
+                    key={t}
+                    className="rounded-full border border-neutral-200 bg-neutral-50 px-[18px] py-2 text-[0.88rem] font-medium text-neutral-500 transition-all hover:border-neutral-300 hover:bg-neutral-100 hover:text-neutral-900"
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
+              <Link
+                data-animate
+                to="/signup"
+                className="inline-flex items-center gap-2 rounded-full bg-neutral-900 px-9 py-[15px] text-base font-semibold text-white shadow-[0_2px_12px_rgba(0,0,0,0.15)] transition-all hover:-translate-y-0.5 hover:bg-neutral-800 hover:shadow-[0_6px_24px_rgba(0,0,0,0.2)]"
+              >
+                지금 시작하기
+                <svg width="18" height="18" viewBox="0 0 20 20" fill="none">
+                  <path
+                    d="M4 10h12m0 0l-4-4m4 4l-4 4"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </Link>
+            </div>
+
+            {/* 우측: 폰 목업 (실제 피드 화면 흉내, 정적) */}
+            <div data-animate className="relative flex justify-center">
+              <div className="w-[300px] rounded-[28px] border border-neutral-200 bg-white p-2.5 shadow-[0_16px_48px_rgba(0,0,0,0.12)] max-[900px]:w-[260px]">
+                <div className="mx-auto mb-2.5 mt-1 h-[5px] w-20 rounded-[10px] bg-neutral-200" />
+                <div className="min-h-[460px] overflow-hidden rounded-[20px] border border-[#eeeeee] bg-white p-3.5">
+                  <div className="pb-3 text-center text-[1.15rem] font-extrabold text-neutral-900">
+                    Mellti
+                  </div>
+                  {/* 탭 */}
+                  <div className="mb-3 flex border-b border-neutral-200">
+                    <span className="flex-1 border-b-2 border-neutral-900 py-2 text-center text-[0.75rem] font-medium text-neutral-900">
+                      전체 피드
+                    </span>
+                    <span className="flex-1 border-b-2 border-transparent py-2 text-center text-[0.75rem] font-medium text-neutral-400">
+                      팔로우
+                    </span>
+                  </div>
+                  {/* 필터 칩 */}
+                  <div className="mb-2.5 flex gap-[5px] overflow-hidden">
+                    <span className="whitespace-nowrap rounded-full border border-neutral-900 bg-neutral-900 px-2.5 py-1 text-[0.6rem] font-medium text-white">
+                      전체
+                    </span>
+                    {['감각통합', '언어치료', '작업치료'].map((c) => (
+                      <span
+                        key={c}
+                        className="whitespace-nowrap rounded-full border border-neutral-300 bg-white px-2.5 py-1 text-[0.6rem] font-medium text-neutral-600"
+                      >
+                        {c}
+                      </span>
+                    ))}
+                  </div>
+                  {/* 정렬 */}
+                  <div className="mb-3 flex gap-2.5 text-[0.62rem] text-neutral-400">
+                    <span className="rounded-full bg-neutral-100 px-2 py-[3px] font-semibold text-neutral-900">
+                      최신순
+                    </span>
+                    <span>인기순</span>
+                  </div>
+                  {/* 고민카드 글 */}
+                  <div className="border-b border-[#eeeeee] py-3">
+                    <div className="mb-2 flex items-center gap-2 text-[0.72rem]">
+                      <div className="h-7 w-7 rounded-full bg-neutral-300" />
+                      <span className="font-semibold text-neutral-900">숨이는 귀엽다</span>
+                      <span className="text-[0.6rem] text-neutral-400">1분 전</span>
+                      <span className="ml-auto text-[0.8rem] text-neutral-300">☐</span>
+                    </div>
+                    <div className="mb-2 rounded-xl border border-neutral-200 bg-neutral-50 p-3">
+                      <div className="mb-2.5 text-[0.72rem] font-bold text-neutral-700">❓ 고민카드</div>
+                      <div className="mb-2.5">
+                        {[
+                          ['연령대', '유아기'],
+                          ['치료영역', '감각통합'],
+                          ['진단명', '자폐스펙트럼장애'],
+                        ].map(([label, value]) => (
+                          <div key={label} className="flex gap-2.5 py-[3px] text-[0.62rem]">
+                            <span className="min-w-[46px] font-semibold text-neutral-500">{label}</span>
+                            <span className="text-neutral-700">{value}</span>
+                          </div>
+                        ))}
+                      </div>
+                      <div className="border-t border-neutral-200 pt-2 text-[0.65rem] leading-relaxed text-neutral-600">
+                        <div className="mb-1 font-bold text-neutral-700">고민지점</div>
+                        만 3세 asd 아동 조절 잡기 어려워서 글 씁니다
+                      </div>
+                    </div>
+                    <div className="flex gap-3.5 text-[0.65rem] text-neutral-400">
+                      <span>💬 0</span>
+                      <span>♡</span>
+                    </div>
+                  </div>
+                  {/* 일반 글 */}
+                  <div className="py-3">
+                    <div className="mb-2 flex items-center gap-2 text-[0.72rem]">
+                      <div className="h-7 w-7 rounded-full bg-neutral-400" />
+                      <span className="font-semibold text-neutral-900">햄스터#2727</span>
+                      <span className="text-[0.6rem] text-neutral-400">8시간 전</span>
+                      <span className="ml-auto text-[0.8rem] text-neutral-300">☐</span>
+                    </div>
+                    <p className="mb-2 text-[0.7rem] leading-relaxed text-neutral-600">
+                      🚩 각 사이트별 최신 채용 공고 모음입니다!
+                    </p>
+                    <div className="flex gap-3.5 text-[0.65rem] text-neutral-400">
+                      <span>💬 0</span>
+                      <span>♡</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
 
         {/* Phase 4: Feature ① 안전한 공간 / 인증 */}
         <section id="feature-safe" className="p-10">[feature-safe]</section>

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { ArrowLeft, Upload } from 'lucide-react';
 import { useAuthStore } from '../../stores/useAuthStore';
 
 /**
@@ -204,8 +205,128 @@ export default function LandingPage() {
           </div>
         </section>
 
-        {/* Phase 4: Feature ① 안전한 공간 / 인증 */}
-        <section id="feature-safe" className="p-10">[feature-safe]</section>
+        {/* Feature ① 안전한 공간 / 인증 — 좌: 인증 화면 목업, 우: 텍스트. 900px↓ 1열(텍스트 먼저). */}
+        <section
+          id="feature-safe"
+          className="relative bg-white px-6 py-[120px] max-[480px]:px-5 max-[480px]:py-20"
+        >
+          <div className="mx-auto grid max-w-[1100px] grid-cols-2 items-center gap-20 max-[900px]:grid-cols-1 max-[900px]:gap-12">
+            {/* 좌: 인증 화면 목업 */}
+            <div data-animate className="max-[900px]:order-2 max-[900px]:flex max-[900px]:justify-center">
+              <div className="w-[300px] rounded-[28px] border border-neutral-200 bg-white p-2.5 shadow-[0_16px_48px_rgba(0,0,0,0.12)] max-[900px]:w-[260px]">
+                <div className="mx-auto mb-2.5 mt-1 h-[5px] w-20 rounded-[10px] bg-neutral-200" />
+                <div className="min-h-[460px] overflow-hidden rounded-[20px] border border-[#eeeeee] bg-white p-3.5">
+                  {/* 실제 TherapistVerificationPage 화면 축소 재현 */}
+                  <div className="mb-3 flex items-center gap-1.5">
+                    <ArrowLeft size={12} className="text-neutral-400" />
+                    <span className="text-[0.8rem] font-bold text-neutral-900">치료사 인증</span>
+                  </div>
+                  <div className="mb-3">
+                    <div className="text-[0.7rem] font-bold text-neutral-900">치료사 인증 페이지</div>
+                    <p className="text-[0.55rem] text-neutral-500">
+                      치료사 자격증을 인증하고 전문 치료사로 활동해보세요.
+                    </p>
+                  </div>
+                  {/* 면허번호 */}
+                  <div className="mb-2.5">
+                    <div className="mb-1 text-[0.6rem] font-semibold text-neutral-700">
+                      면허번호 <span className="text-red-500">*</span>
+                    </div>
+                    <div className="rounded-md border border-neutral-200 px-2 py-1.5 text-[0.58rem] text-neutral-400">
+                      면허번호를 입력해주세요
+                    </div>
+                  </div>
+                  {/* 면허증 첨부 */}
+                  <div className="mb-2.5">
+                    <div className="mb-1 text-[0.6rem] font-semibold text-neutral-700">
+                      준비물: 면허증 첨부 <span className="text-red-500">*</span>
+                    </div>
+                    <div className="flex flex-col items-center gap-1 rounded-md border-2 border-dashed border-neutral-200 py-3 text-neutral-400">
+                      <Upload size={14} />
+                      <span className="text-[0.55rem]">파일을 선택하거나 드래그하세요</span>
+                      <span className="text-[0.5rem] text-neutral-300">JPG, PNG, WEBP (최대 5MB)</span>
+                    </div>
+                  </div>
+                  {/* 치료영역 (9개, 3열, 중복 선택) */}
+                  <div className="mb-3">
+                    <div className="text-[0.6rem] font-semibold text-neutral-700">
+                      추가 수집 정보: 치료영역 <span className="text-red-500">*</span>
+                    </div>
+                    <p className="mb-1.5 text-[0.5rem] text-neutral-400">
+                      인정하시는 치료 영역을 선택하세요 (중복 선택 가능)
+                    </p>
+                    <div className="grid grid-cols-3 gap-1">
+                      {[
+                        ['감각통합', true],
+                        ['언어치료', true],
+                        ['작업치료', false],
+                        ['인지치료', false],
+                        ['물리치료', false],
+                        ['미술치료', false],
+                        ['음악치료', false],
+                        ['놀이치료', false],
+                        ['행동치료', false],
+                      ].map(([area, selected]) => (
+                        <span
+                          key={area as string}
+                          className={`rounded-md border py-1 text-center text-[0.52rem] font-medium ${
+                            selected
+                              ? 'border-neutral-900 bg-neutral-900 text-white'
+                              : 'border-neutral-200 bg-white text-neutral-600'
+                          }`}
+                        >
+                          {area}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  {/* 버튼 (취소 / 인증 신청하기 violet) */}
+                  <div className="flex gap-1.5">
+                    <div className="flex-1 rounded-md border border-neutral-200 py-1.5 text-center text-[0.6rem] font-medium text-neutral-600">
+                      취소
+                    </div>
+                    <div className="flex-1 rounded-md bg-violet-500 py-1.5 text-center text-[0.6rem] font-medium text-white">
+                      인증 신청하기
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* 우: 텍스트 */}
+            <div data-animate className="max-[900px]:order-1">
+              <span className="mb-4 inline-block rounded-full border border-neutral-200 bg-neutral-100 px-3.5 py-[5px] text-[0.8rem] font-semibold text-neutral-500">
+                안전한 전문가 공간
+              </span>
+              <h2 className="mb-4 text-[clamp(1.6rem,3vw,2.3rem)] font-extrabold leading-[1.35] tracking-[-0.5px] text-neutral-900">
+                치료사들만의
+                <br />
+                <span className="font-extrabold">안전한 공간</span>
+              </h2>
+              <p className="mb-8 text-base leading-[1.8] text-neutral-500">
+                면허증 인증을 통해 검증된 치료사만 접근할 수 있는 전문가 커뮤니티입니다. 인증 회원은 닉네임
+                옆에 치료영역이 표시되어, 신뢰할 수 있는 동료와 소통하세요.
+              </p>
+              <ul className="flex flex-col gap-5">
+                {[
+                  ['🔐', '면허증 기반 인증', '치료사 자격을 증빙하여 인증 회원 등급을 획득'],
+                  ['🏷️', '치료영역 표시', 'ST, OT, PT 등 전문 분야가 닉네임과 함께 표시'],
+                  ['👁️', '단계별 접근 권한', '인증 등급에 따라 열람 가능한 게시글이 달라져요'],
+                ].map(([icon, title, desc]) => (
+                  <li key={title} className="flex items-start gap-3.5">
+                    <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-neutral-200 bg-neutral-50 text-[1.2rem]">
+                      {icon}
+                    </span>
+                    <div>
+                      <strong className="mb-0.5 block text-[0.95rem] font-semibold">{title}</strong>
+                      <p className="text-[0.85rem] leading-[1.5] text-neutral-500">{desc}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
 
         {/* Phase 5: Feature ② 고민카드 */}
         <section id="feature-worry" className="p-10">[feature-worry]</section>

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -1,3 +1,6 @@
+import { Link } from 'react-router-dom';
+import { useAuthStore } from '../../stores/useAuthStore';
+
 /**
  * Mellti 랜딩 페이지 (비로그인 진입 화면).
  *
@@ -6,13 +9,48 @@
  * - prerender 대상(`src/prerender.tsx`)이라 SSR 가능해야 함 → 초기 렌더는
  *   브라우저 전용 API(IntersectionObserver 등) 없이 정적으로 그려지도록 유지.
  *
- * Phase 1: 섹션 골격만. 각 섹션 내용은 이후 Phase에서 Tailwind로 채움.
+ * 색상: 와이어프레임의 --gray-* 디자인 토큰은 Tailwind neutral-* 팔레트와 16진수까지 1:1.
  */
 export default function LandingPage() {
+  const user = useAuthStore((s) => s.user);
+
   return (
     <div className="min-h-screen bg-white font-sans text-neutral-900">
-      {/* Phase 2: 네비게이션 */}
-      <nav id="nav" className="border-b border-neutral-200 p-4">[nav]</nav>
+      {/* 상단 고정 네비게이션 (반투명 + blur). 높이 64px = h-16. */}
+      <nav
+        id="nav"
+        className="fixed inset-x-0 top-0 z-50 h-16 border-b border-neutral-200 bg-white/85 backdrop-blur-xl"
+      >
+        <div className="mx-auto flex h-full max-w-[1200px] items-center justify-between px-6">
+          <Link to="/" className="text-[1.4rem] font-extrabold tracking-[-0.5px] text-neutral-900">
+            Mellti
+          </Link>
+          <div className="flex items-center gap-4">
+            {/* TODO(협업문의): 실제 타겟 미정 — 문의 폼/메일 주소 확정 후 연결 */}
+            <a
+              href="#"
+              className="text-sm font-medium text-neutral-500 transition-colors hover:text-neutral-900"
+            >
+              협업문의
+            </a>
+            {user ? (
+              <Link
+                to="/posts"
+                className="inline-flex items-center rounded-full bg-neutral-900 px-6 py-2.5 text-sm font-semibold text-white transition-all hover:bg-neutral-700"
+              >
+                커뮤니티
+              </Link>
+            ) : (
+              <Link
+                to="/login"
+                className="inline-flex items-center rounded-full bg-neutral-900 px-6 py-2.5 text-sm font-semibold text-white transition-all hover:bg-neutral-700"
+              >
+                로그인
+              </Link>
+            )}
+          </div>
+        </div>
+      </nav>
 
       <main>
         {/* Phase 3: Hero (폰 목업 포함) */}

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -529,12 +529,86 @@ export default function LandingPage() {
           </div>
         </section>
 
-        {/* Phase 7: CTA */}
-        <section id="cta" className="p-10">[cta]</section>
+        {/* CTA — 다크 배경 + 반전 버튼 */}
+        <section
+          id="cta"
+          className="relative overflow-hidden bg-neutral-900 px-6 py-[120px] text-center text-white max-[480px]:px-5 max-[480px]:py-20"
+        >
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(255,255,255,0.03)_0%,transparent_60%)]" />
+          <div data-animate className="relative z-10">
+            <h2 className="mb-4 text-[clamp(1.8rem,3.5vw,2.6rem)] font-extrabold leading-[1.35] tracking-[-0.5px]">
+              임상 현장의 고민,
+              <br />
+              이제 <span className="text-neutral-300">Mellti</span>에서 나누세요
+            </h2>
+            <p className="mb-9 text-[1.05rem] text-neutral-400">
+              전국의 치료사 동료들이 기다리고 있어요
+            </p>
+            <Link
+              to="/login"
+              className="inline-flex items-center gap-2 rounded-full bg-white px-9 py-[15px] text-base font-semibold text-neutral-900 shadow-[0_2px_16px_rgba(255,255,255,0.1)] transition-all hover:-translate-y-0.5 hover:bg-neutral-100 hover:shadow-[0_6px_30px_rgba(255,255,255,0.15)]"
+            >
+              로그인하러 가기
+              <svg width="18" height="18" viewBox="0 0 20 20" fill="none">
+                <path
+                  d="M4 10h12m0 0l-4-4m4 4l-4 4"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </Link>
+          </div>
+        </section>
       </main>
 
-      {/* Phase 8: Footer */}
-      <footer id="footer" className="border-t border-neutral-200 p-4">[footer]</footer>
+      {/* Footer — 브랜드 + 링크 + 회사 정보 */}
+      <footer id="footer" className="border-t border-neutral-200 bg-neutral-50 px-6 pb-8 pt-12">
+        <div className="mx-auto max-w-[1100px]">
+          <div className="mb-8 flex flex-wrap items-start justify-between gap-5">
+            <div className="flex flex-col gap-1.5">
+              <span className="text-[1.4rem] font-extrabold tracking-[-0.5px] text-neutral-900">
+                Mellti
+              </span>
+              <p className="text-[0.85rem] text-neutral-400">치료사들의 성장 바다</p>
+            </div>
+            <div className="flex items-center gap-5">
+              <Link
+                to="/terms"
+                className="text-[0.85rem] text-neutral-400 transition-colors hover:text-neutral-900"
+              >
+                이용약관
+              </Link>
+              <Link
+                to="/privacy"
+                className="text-[0.85rem] text-neutral-400 transition-colors hover:text-neutral-900"
+              >
+                개인정보 처리방침
+              </Link>
+              {/* TODO(인스타): 아이로 공식 인스타그램 URL 확정 후 href 연결 */}
+              <a
+                href="#"
+                aria-label="아이로 인스타그램"
+                className="text-neutral-400 transition-colors hover:text-neutral-900"
+              >
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z" />
+                </svg>
+              </a>
+            </div>
+          </div>
+          <div className="border-t border-neutral-200 pt-5">
+            {/* TODO(사업자번호): 실제 사업자등록번호 확정 후 교체 */}
+            <p className="text-[0.78rem] leading-[1.8] text-neutral-400">
+              주식회사 아이로 | 사업자등록번호: 000-00-00000
+            </p>
+            <p className="text-[0.78rem] leading-[1.8] text-neutral-400">
+              © 2026 Airo Inc. All rights reserved.
+            </p>
+          </div>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -468,8 +468,66 @@ export default function LandingPage() {
           </div>
         </section>
 
-        {/* Phase 6: Feature ③ 커뮤니티 기능 */}
-        <section id="feature-community" className="p-10">[feature-community]</section>
+        {/* Feature ③ 커뮤니티 기능 — 좌: 카드 4개 스택, 우: 텍스트. 900px↓ 1열(텍스트 먼저). */}
+        <section
+          id="feature-community"
+          className="relative bg-white px-6 py-[120px] max-[480px]:px-5 max-[480px]:py-20"
+        >
+          <div className="mx-auto grid max-w-[1100px] grid-cols-2 items-center gap-20 max-[900px]:grid-cols-1 max-[900px]:gap-12">
+            {/* 좌: 기능 카드 4개 (2x2) */}
+            <div data-animate className="max-[900px]:order-2 max-[900px]:flex max-[900px]:justify-center">
+              <div className="mx-auto grid max-w-[380px] grid-cols-2 gap-3.5 max-[480px]:max-w-[280px]">
+                {[
+                  ['💬', '1:1 메시지', '동료 치료사와 직접 소통'],
+                  ['🔔', '실시간 알림', '댓글, 리액션, DM 알림'],
+                  ['👥', '팔로우 피드', '관심 치료사의 글만 모아보기'],
+                  ['🔄', '리포스트', '유용한 글을 공유하고 인용'],
+                ].map(([icon, title, desc]) => (
+                  <div
+                    key={title}
+                    className="rounded-[20px] border border-neutral-200 bg-white px-[18px] py-7 text-center shadow-[0_1px_3px_rgba(0,0,0,0.06)] transition-all hover:-translate-y-1.5 hover:border-neutral-300 hover:shadow-[0_8px_32px_rgba(0,0,0,0.1)] max-[480px]:px-3 max-[480px]:py-5"
+                  >
+                    <div className="mb-2.5 text-[1.8rem]">{icon}</div>
+                    <h4 className="mb-1 text-[0.88rem] font-bold text-neutral-800">{title}</h4>
+                    <p className="text-[0.75rem] text-neutral-400">{desc}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* 우: 텍스트 */}
+            <div data-animate className="max-[900px]:order-1">
+              <span className="mb-4 inline-block rounded-full border border-neutral-200 bg-neutral-100 px-3.5 py-[5px] text-[0.8rem] font-semibold text-neutral-500">
+                커뮤니티 기능
+              </span>
+              <h2 className="mb-4 text-[clamp(1.6rem,3vw,2.3rem)] font-extrabold leading-[1.35] tracking-[-0.5px] text-neutral-900">
+                치료사를 위한
+                <br />
+                <span className="font-extrabold">모든 기능</span>
+              </h2>
+              <p className="mb-8 text-base leading-[1.8] text-neutral-500">
+                팔로우, 메시지, 리포스트 등 커뮤니티에 필요한 모든 기능을 갖추고 있어요. 같은 고민을
+                나누는 동료를 찾고, 함께 성장하세요.
+              </p>
+              <ul className="flex flex-col gap-5">
+                {[
+                  ['❤️', '3종 리액션', '좋아요, 유용해요, 궁금해요로 감정 표현'],
+                  ['⏳', '휘발성 게시글', '일정 시간 후 자동 삭제되는 게시글 기능'],
+                ].map(([icon, title, desc]) => (
+                  <li key={title} className="flex items-start gap-3.5">
+                    <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-neutral-200 bg-neutral-50 text-[1.2rem]">
+                      {icon}
+                    </span>
+                    <div>
+                      <strong className="mb-0.5 block text-[0.95rem] font-semibold">{title}</strong>
+                      <p className="text-[0.85rem] leading-[1.5] text-neutral-500">{desc}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
 
         {/* Phase 7: CTA */}
         <section id="cta" className="p-10">[cta]</section>

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -1,0 +1,38 @@
+/**
+ * Mellti 랜딩 페이지 (비로그인 진입 화면).
+ *
+ * - Layout(공통 네비/사이드바) 밖 standalone. 자체 nav/footer를 가짐.
+ * - `/` 라우트에 직결. 로그인 여부와 무관하게 모두에게 노출(로그인 유저는 nav로 /posts 이동).
+ * - prerender 대상(`src/prerender.tsx`)이라 SSR 가능해야 함 → 초기 렌더는
+ *   브라우저 전용 API(IntersectionObserver 등) 없이 정적으로 그려지도록 유지.
+ *
+ * Phase 1: 섹션 골격만. 각 섹션 내용은 이후 Phase에서 Tailwind로 채움.
+ */
+export default function LandingPage() {
+  return (
+    <div className="min-h-screen bg-white font-sans text-neutral-900">
+      {/* Phase 2: 네비게이션 */}
+      <nav id="nav" className="border-b border-neutral-200 p-4">[nav]</nav>
+
+      <main>
+        {/* Phase 3: Hero (폰 목업 포함) */}
+        <section id="hero" className="p-10">[hero]</section>
+
+        {/* Phase 4: Feature ① 안전한 공간 / 인증 */}
+        <section id="feature-safe" className="p-10">[feature-safe]</section>
+
+        {/* Phase 5: Feature ② 고민카드 */}
+        <section id="feature-worry" className="p-10">[feature-worry]</section>
+
+        {/* Phase 6: Feature ③ 커뮤니티 기능 */}
+        <section id="feature-community" className="p-10">[feature-community]</section>
+
+        {/* Phase 7: CTA */}
+        <section id="cta" className="p-10">[cta]</section>
+      </main>
+
+      {/* Phase 8: Footer */}
+      <footer id="footer" className="border-t border-neutral-200 p-4">[footer]</footer>
+    </div>
+  );
+}

--- a/frontend/src/pages/post/CommentWritePage.tsx
+++ b/frontend/src/pages/post/CommentWritePage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import DOMPurify from 'dompurify';
 import { Eye, MoreVertical } from 'lucide-react';
-import VerifiedBadge from '../../components/post/VerifiedBadge';
 import ReactionBar from '../../components/post/ReactionBar';
 import { useReactionToggle, reactionFromPostDetail } from '../../hooks/useReactionToggle';
 import { Badge } from '@/components/shadcn-ui/badge';
@@ -107,7 +106,6 @@ export default function CommentWritePage() {
           <div>
             <div className="flex items-center gap-2">
               <span className="text-sm font-semibold text-gray-900">{post.authorNickname}</span>
-              <VerifiedBadge status={post.authorVerificationStatus} />
               {therapyLabel && (
                 <Badge variant="secondary" className="text-xs">
                   {therapyLabel}

--- a/frontend/src/pages/post/PostDetailPage.tsx
+++ b/frontend/src/pages/post/PostDetailPage.tsx
@@ -13,7 +13,6 @@ import {
   Image as ImageIcon,
 } from 'lucide-react';
 import ReactionBar from '../../components/post/ReactionBar';
-import VerifiedBadge from '../../components/post/VerifiedBadge';
 import { useReactionToggle, reactionFromPostDetail } from '../../hooks/useReactionToggle';
 import CommentCard from '../../components/post/CommentCard';
 import CommentInput from '../../components/post/CommentInput';
@@ -322,7 +321,6 @@ export default function PostDetailPage() {
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2">
                 <span className="text-sm font-semibold text-gray-900">{post.authorNickname}</span>
-                <VerifiedBadge status={post.authorVerificationStatus} />
                 {post.visibility === 'PRIVATE' && (
                   <span
                     className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-gray-100 text-gray-600 text-[11px] font-medium"

--- a/frontend/src/prerender.tsx
+++ b/frontend/src/prerender.tsx
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react';
 import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom';
+import LandingPage from './pages/landing/LandingPage';
 import PrivacyPage from './pages/PrivacyPage';
 import TermsPage from './pages/TermsPage';
 
@@ -23,18 +24,16 @@ const META_BY_URL: Record<string, PageMeta> = {
 };
 
 /**
- * 랜딩페이지 폐기(2026-05-06) 후 `/`은 hydrate 시 RootRedirect가 즉시 /signup·/posts로
- * navigate. description meta만으로는 Googlebot이 본문(/signup) 자동 추출을 우선해서
- * 검색 결과 부연설명에 회원가입 폼 텍스트가 잡히는 문제 확인(2026-05-15).
+ * 랜딩 부활(2026-06-06) 후 `/` prerender 본체는 실제 LandingPage.
  *
- * 그래서 sr-only 본문에 PM SEO 키워드(핵심5·영역10·정보성11)를 자연어로 박아
- * prerender HTML에 콘텐츠 시그널을 주입함. 사용자 화면에는 안 보이므로 UX 영향 0,
- * hydrate 직후 RootRedirect로 정상 이동.
+ * 추가로 PM SEO 롱테일 키워드(핵심5·영역10·정보성11)를 sr-only 블록으로 함께 prerender한다.
+ * LandingPage 본문이 커버하지 못하는 롱테일(활동지·구인구직 시설명·논문·번아웃 등)을 보존하기 위함.
+ * 이 블록은 prerender HTML(봇이 읽는 정적 산출물)에만 존재하고, 클라이언트 SPA는 LandingPage만
+ * 렌더하므로 실유저 DOM에는 노출되지 않는다(hidden-text 리스크 최소화).
  */
-function SeoRoot() {
+function SeoKeywords() {
   return (
     <div className="sr-only">
-      <h1>Mellti — 발달재활 치료사 커뮤니티</h1>
       <p>
         언어치료사·작업치료사·물리치료사·놀이치료사·특수교사를 비롯한 발달재활 치료사를 위한 커뮤니티
         Mellti. 활동지 공유, 보수교육 정보, 발달센터·병원·부설센터·사회복지관·장애인복지관 구인구직을 한
@@ -50,8 +49,18 @@ function SeoRoot() {
   );
 }
 
+/** `/` prerender = 실제 랜딩 본문 + SEO 키워드 블록. */
+function LandingPrerender() {
+  return (
+    <>
+      <LandingPage />
+      <SeoKeywords />
+    </>
+  );
+}
+
 const ROUTES: Record<string, ComponentType> = {
-  '/': SeoRoot,
+  '/': LandingPrerender,
   '/privacy': PrivacyPage,
   '/terms': TermsPage,
 };


### PR DESCRIPTION
## 배경
팀 결정으로 랜딩 페이지 부활(2026-05-06 폐기 뒤집힘). 목적 = **SEO 향상** + **비로그인 진입 콘텐츠**(랜딩 자체). PM 와이어프레임(HTML/CSS) 기반.

## 변경 요약
- `/` = 로그인 여부 무관 `LandingPage` 직결, `RootRedirect` 삭제 (로그인 유저는 nav "커뮤니티"→`/posts`)
- 브랜드 = **Mellti** / 회사 = 주식회사 아이로
- 와이어프레임 → **Tailwind 전면 재작성** (`--gray-*` 토큰 = `neutral-*` 16진수 1:1)
- 구조: Nav(auth-aware) → Hero(폰 목업) → Feature①인증 → ②고민카드 → ③커뮤니티 → CTA → Footer
- **폰 목업 3종 = 실제 화면 재현**: Hero 피드 / Feature① `TherapistVerificationPage` / Feature② `ConcernForm`
- **스크롤 등장 애니메이션** `useScrollReveal` — progressive enhancement (마크업 기본 노출, JS 있을 때만 숨김→등장 → 봇/no-JS/prerender 전부 보임)
- **SEO**: prerender `/` 본체를 sr-only 해킹(`SeoRoot`) → 실제 `LandingPage`로 교체, PM 롱테일 키워드는 `SeoKeywords` sr-only 블록으로 prerender HTML에만 보존

## 검증
- `tsc -b` 통과, prod 빌드 통과(prerender 3페이지)
- 동적 Tailwind 클래스(opacity-0 등) purge 생존 확인 (번들 CSS grep)
- prerender `/`에 실제 본문 + SEO 키워드 존재, `opacity-0` 0회(숨김 미박힘) 확인

## 후속 (backlog F-11)
- placeholder 3개 미확정: 협업문의 링크 / 아이로 인스타 URL / 사업자등록번호(현 `000-00-00000` 더미) — 코드에 `TODO` 주석
- 카피↔실제 갭: Feature③ 광고 기능 중 팔로우 피드·리포스트·휘발성 게시글 미구현 가능성 → PM 카피 조정 검토

## 리뷰 포인트
- 폰 목업이 실제 화면과 충실히 일치하는지
- progressive enhancement 동작 (스크롤 시 등장, JS off 시 전부 보임)
- 미구현 기능 카피를 이대로 둘지

---

## 업데이트 (2026-06-07) — Hero 목업 실화면 정합 + 인증뱃지 죽은코드 제거

리뷰 중 Hero 폰 목업이 실제 `/posts` 피드와 어긋나는 점들을 발견해 정합:
- 북마크 아이콘: 빈 네모(☐) → lucide Bookmark SVG
- 댓글/하트: 이모지(💬 ♡) → lucide MessageCircle / Heart
- 고민카드: 인라인 ❓ → 회색 헤더바 + 원형 `?` 뱃지 (실제 `ConcernCard` 구조)
- 진단명: 평문 → 알약(pill) 칩
- 정렬칩: 최신순 active=검정bg/흰글씨, 인기순=테두리 (명암 실제와 일치)
- 필터칩·정렬 섹션 `border-b` 구분선 추가, 미선택 칩 글자색 정합

**인증뱃지(`authorVerificationStatus`) 죽은코드 제거**:
- 백엔드 `/posts`·`/posts/feed` 응답에 `authorVerificationStatus` 필드가 없어 항상 미렌더되던 코드 확인 → `PostCard`·`PostDetailPage`·`CommentWritePage` 3곳의 `VerifiedBadge` 사용+import 삭제
- `authorRole` / `user.therapistVerification` 기반 살아있는 경로는 유지
- 타입(`types/post.ts`)·MSW 목 데이터는 백엔드 필드 추가 시 부활 위해 보존
- ⚠️ Feature① 카피("닉네임과 함께 치료영역/인증 표시")가 현재 실동작과 불일치 → 카피갭 backlog **F-11**에 포함

→ 리뷰 포인트 ①(폰 목업 실화면 일치)은 본 업데이트로 해소.
