### PR TITLE
feat(follow): 팔로우 기능 1차 — 목록 페이지 + 언팔 토글 + 작성자 드롭다운 팔로우

### DIFF
--- a/docs/superpowers/plans/2026-06-08-follow-list-toggle.md
+++ b/docs/superpowers/plans/2026-06-08-follow-list-toggle.md
@@ -1,0 +1,541 @@
+# 팔로우 목록 + 언팔로우 토글 — 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/follow` 페이지(팔로잉/팔로워 2탭, "더보기" 페이지네이션) + 팔로잉 탭 행별 언팔로우 토글 + ProfilePage 헤더 팔로우 카운트 진입점을 구현한다.
+
+**Architecture:** 신규 4파일(types/api/hook/page) + ProfilePage·App.tsx 변경. 목록은 RQ `useInfiniteQuery`(offset, "더보기"), 카운트는 `useQuery`, 토글은 페이지-레벨 낙관적 상태(언팔된 userId Set) + 응답 reconcile + 실패 롤백(sonner 토스트). 기존 패턴(`NarrowPage`/`PageHeader`/`UserAvatar`/쪽지함 탭) 재사용.
+
+**Tech Stack:** React 19 + TS, React Router(`useSearchParams`), TanStack Query(`useInfiniteQuery`/`useQuery`), Tailwind, sonner(toast), axios(`axiosInstance` + envelope 인터셉터).
+
+**검증 방식 주의:** 이 프로젝트엔 **단위 테스트 러너가 없다**(vitest/jest 미설치). 각 태스크의 검증 = `npx tsc -b` 타입체크 통과 + 마지막 태스크의 브라우저 수동 검증. 테스트 프레임워크를 새로 도입하지 않는다(스코프·의존성 규율).
+
+**설계 문서:** `docs/superpowers/specs/2026-06-08-follow-list-toggle-design.md`
+
+---
+
+## 파일 구조
+
+| 파일 | 책임 | 신규/변경 |
+|---|---|---|
+| `frontend/src/types/follow.ts` | 팔로우 도메인 타입 4종 | 신규 |
+| `frontend/src/api/follow.ts` | 팔로우 엔드포인트 호출 + envelope 언랩 | 신규 |
+| `frontend/src/hooks/useFollowToggle.ts` | 팔로잉 탭 행별 낙관적 토글 | 신규 |
+| `frontend/src/pages/follow/FollowListPage.tsx` | `/follow` 페이지(탭/목록/더보기/토글) | 신규 |
+| `frontend/src/App.tsx` | `/follow` 라우트 등록 | 변경 |
+| `frontend/src/pages/profile/ProfilePage.tsx` | 헤더 팔로우 카운트(실데이터+링크) | 변경 |
+
+---
+
+## Task 0: 피처 브랜치 생성
+
+**Files:** 없음(브랜치만)
+
+- [ ] **Step 1: develop 최신화 후 브랜치 분기**
+
+Run:
+```bash
+cd /home/jin24/MelloMe_FE_Backup
+git checkout develop && git pull
+git checkout -b feat/follow-list
+```
+Expected: `Switched to a new branch 'feat/follow-list'`
+
+---
+
+## Task 1: 팔로우 타입 정의
+
+**Files:**
+- Create: `frontend/src/types/follow.ts`
+
+- [ ] **Step 1: 타입 파일 작성**
+
+`frontend/src/types/follow.ts`:
+```ts
+// 팔로우 목록 행 — /me/followings, /me/followers 공유 DTO.
+// 주의: 백엔드 FollowUserResponse에는 "내가 이 사람을 팔로우 중인가"(following) 필드가 없다.
+//       팔로워 탭 맞팔 버튼은 그래서 이번 슬라이스 제외(backlog F-12).
+export interface FollowUser {
+  userId: number;
+  nickname: string;
+  profileImageUrl?: string | null;
+  role: string;
+}
+
+// POST/DELETE/GET /users/{userId}/follow 응답.
+export interface FollowStatus {
+  userId: number;
+  following: boolean;
+}
+
+// GET /me/follow-counts 응답.
+export interface FollowCount {
+  followerCount: number;
+  followingCount: number;
+}
+
+// offset 페이지 응답 (커서 아님 — page/totalPages/hasNext).
+export interface PagedFollowUsers {
+  items: FollowUser[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  hasNext: boolean;
+}
+```
+
+- [ ] **Step 2: 타입체크**
+
+Run: `cd frontend && npx tsc -b`
+Expected: 에러 없이 통과(미사용 타입은 export라 경고 없음).
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add frontend/src/types/follow.ts
+git commit -m "feat(follow): 팔로우 도메인 타입 정의"
+```
+
+---
+
+## Task 2: 팔로우 API 함수
+
+**Files:**
+- Create: `frontend/src/api/follow.ts`
+
+- [ ] **Step 1: API 파일 작성**
+
+`frontend/src/api/follow.ts`:
+```ts
+import axiosInstance from './axiosInstance';
+import type { FollowCount, PagedFollowUsers, FollowStatus } from '../types/follow';
+
+// 응답 인터셉터(axiosInstance.ts:35-40)가 {success,data}를 data로 언랩하지만,
+// 최신 형제 모듈(api/messages.ts)과 동일하게 방어적으로 한 번 더 언랩한다.
+export async function fetchFollowCounts(): Promise<FollowCount> {
+  const res = await axiosInstance.get('/me/follow-counts');
+  return res.data?.data ?? res.data;
+}
+
+export async function fetchFollowings(page = 0, size = 10): Promise<PagedFollowUsers> {
+  const res = await axiosInstance.get('/me/followings', { params: { page, size } });
+  return res.data?.data ?? res.data;
+}
+
+export async function fetchFollowers(page = 0, size = 10): Promise<PagedFollowUsers> {
+  const res = await axiosInstance.get('/me/followers', { params: { page, size } });
+  return res.data?.data ?? res.data;
+}
+
+export async function followUser(userId: number): Promise<FollowStatus> {
+  const res = await axiosInstance.post(`/users/${userId}/follow`);
+  return res.data?.data ?? res.data;
+}
+
+export async function unfollowUser(userId: number): Promise<FollowStatus> {
+  const res = await axiosInstance.delete(`/users/${userId}/follow`);
+  return res.data?.data ?? res.data;
+}
+```
+
+> 참고: `getFollowStatus(GET /users/{id}/follow)`는 이번 슬라이스에서 미사용이라 YAGNI로 생략. 백로그 F-12(맞팔 버튼) 착수 시 추가.
+
+- [ ] **Step 2: 타입체크**
+
+Run: `cd frontend && npx tsc -b`
+Expected: 통과.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add frontend/src/api/follow.ts
+git commit -m "feat(follow): 팔로우 API 함수 (counts/목록/POST/DELETE)"
+```
+
+---
+
+## Task 3: 토글 훅 `useFollowToggle`
+
+**Files:**
+- Create: `frontend/src/hooks/useFollowToggle.ts`
+
+설계: 팔로잉 탭은 로드 시 전원 `following=true`이므로, "이번 세션에서 언팔된 userId"만 `Set`으로 추적한다(기본=팔로잉). 낙관적 반영 → 응답 `following`으로 reconcile → 실패 시 롤백. 단일 in-flight 가드.
+
+- [ ] **Step 1: 훅 파일 작성**
+
+`frontend/src/hooks/useFollowToggle.ts`:
+```ts
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
+import { followUser, unfollowUser } from '../api/follow';
+import type { FollowUser } from '../types/follow';
+
+// 팔로잉 탭 행 단위 낙관적 팔로우/언팔 토글.
+// 댓글 리액션 B패턴(useCommentReactionToggle)을 목록 행에 맞게 변형.
+export function useFollowToggle() {
+  const qc = useQueryClient();
+  // 이번 세션에서 언팔된 userId 집합. 비어있음 = 전원 팔로잉(팔로잉 탭 초기 상태).
+  const [unfollowed, setUnfollowed] = useState<Set<number>>(new Set());
+  const [pendingId, setPendingId] = useState<number | null>(null);
+
+  const isFollowing = (userId: number) => !unfollowed.has(userId);
+
+  function applyUnfollow(userId: number, shouldUnfollow: boolean) {
+    setUnfollowed((prev) => {
+      const next = new Set(prev);
+      if (shouldUnfollow) next.add(userId);
+      else next.delete(userId);
+      return next;
+    });
+  }
+
+  async function toggle(user: FollowUser) {
+    if (pendingId !== null) return; // 한 번에 한 행만
+    const userId = user.userId;
+    const currentlyFollowing = isFollowing(userId);
+    setPendingId(userId);
+
+    // 낙관적 반영: 팔로잉이면 언팔, 아니면 재팔로우
+    applyUnfollow(userId, currentlyFollowing);
+
+    try {
+      const fresh = currentlyFollowing
+        ? await unfollowUser(userId)
+        : await followUser(userId);
+      // 서버 응답으로 reconcile (following=false → 언팔 상태로 고정)
+      applyUnfollow(userId, !fresh.following);
+      qc.invalidateQueries({ queryKey: ['follow-counts'] });
+    } catch (err) {
+      // 롤백: 낙관적 반영을 되돌림
+      applyUnfollow(userId, !currentlyFollowing);
+      console.error('[follow]', err);
+      toast.error('처리에 실패했어요. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  return { isFollowing, toggle, pendingId };
+}
+```
+
+- [ ] **Step 2: 타입체크**
+
+Run: `cd frontend && npx tsc -b`
+Expected: 통과(`FollowUser` import 사용됨).
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add frontend/src/hooks/useFollowToggle.ts
+git commit -m "feat(follow): 낙관적 언팔/팔로우 토글 훅"
+```
+
+---
+
+## Task 4: `/follow` 페이지 + 라우트
+
+**Files:**
+- Create: `frontend/src/pages/follow/FollowListPage.tsx`
+- Modify: `frontend/src/App.tsx`
+
+- [ ] **Step 1: 페이지 작성**
+
+`frontend/src/pages/follow/FollowListPage.tsx`:
+```tsx
+import { useSearchParams } from 'react-router-dom';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import PageHeader from '../../components/common/PageHeader';
+import NarrowPage from '../../components/common/NarrowPage';
+import UserAvatar from '../../components/common/UserAvatar';
+import { fetchFollowings, fetchFollowers } from '../../api/follow';
+import { useFollowToggle } from '../../hooks/useFollowToggle';
+import type { FollowUser, PagedFollowUsers } from '../../types/follow';
+
+const PAGE_SIZE = 10;
+type Tab = 'followings' | 'followers';
+
+// role enum → 한국어 라벨. 미지의 값은 원문 노출(방어적).
+const ROLE_LABEL: Record<string, string> = {
+  THERAPIST: '치료사',
+  ADMIN: '관리자',
+  USER: '회원',
+};
+
+export default function FollowListPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab: Tab = searchParams.get('tab') === 'followers' ? 'followers' : 'followings';
+
+  const { isFollowing, toggle, pendingId } = useFollowToggle();
+
+  const query = useInfiniteQuery({
+    queryKey: ['follow', tab],
+    queryFn: ({ pageParam }) =>
+      tab === 'followings'
+        ? fetchFollowings(pageParam, PAGE_SIZE)
+        : fetchFollowers(pageParam, PAGE_SIZE),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage: PagedFollowUsers) =>
+      lastPage.hasNext ? lastPage.page + 1 : undefined,
+    staleTime: 30_000,
+  });
+
+  const users: FollowUser[] = query.data?.pages.flatMap((p) => p.items) ?? [];
+
+  function switchTab(next: Tab) {
+    if (next === tab) return;
+    setSearchParams({ tab: next });
+  }
+
+  return (
+    <NarrowPage>
+      <PageHeader title="팔로우" backTo="/profile" />
+
+      {/* 팔로잉/팔로워 탭 — 쪽지함과 동일 컨벤션 */}
+      <div className="sticky top-0 z-40 bg-white border-b border-gray-200">
+        <div className="flex">
+          {(
+            [
+              ['followings', '팔로잉'],
+              ['followers', '팔로워'],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              onClick={() => switchTab(value)}
+              className={`flex-1 py-2.5 text-xs font-medium text-center transition-colors ${
+                tab === value ? 'text-neutral-950 border-b-2 border-black' : 'text-gray-400'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {query.isLoading ? (
+        <div className="px-4 py-12 text-center text-gray-400 text-sm">불러오는 중...</div>
+      ) : query.isError ? (
+        <div className="flex flex-col items-center gap-3 py-12">
+          <p className="text-sm text-destructive">목록을 불러오지 못했어요.</p>
+          <button
+            onClick={() => query.refetch()}
+            className="px-4 py-2 text-sm font-medium border border-gray-300 rounded-lg hover:bg-gray-50"
+          >
+            재시도
+          </button>
+        </div>
+      ) : users.length === 0 ? (
+        <div className="px-4 py-12 text-center text-gray-400 text-sm">
+          {tab === 'followings'
+            ? '아직 팔로우한 치료사가 없어요'
+            : '아직 나를 팔로우한 사람이 없어요'}
+        </div>
+      ) : (
+        <>
+          <ul>
+            {users.map((u) => (
+              <li
+                key={u.userId}
+                className="flex items-center gap-3 px-4 py-3 border-b border-gray-100"
+              >
+                <UserAvatar nickname={u.nickname} imageUrl={u.profileImageUrl} size="md" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-900 truncate">{u.nickname}</p>
+                  <p className="text-xs text-gray-400">{ROLE_LABEL[u.role] ?? u.role}</p>
+                </div>
+                {/* 팔로잉 탭만 토글 버튼. 팔로워 탭은 명단 표시만(맞팔 버튼=backlog F-12) */}
+                {tab === 'followings' && (
+                  <button
+                    onClick={() => toggle(u)}
+                    disabled={pendingId === u.userId}
+                    className={`text-xs px-3 py-1.5 rounded-full border transition-colors disabled:opacity-50 ${
+                      isFollowing(u.userId)
+                        ? 'text-gray-500 border-gray-300 hover:border-gray-400'
+                        : 'bg-gray-900 text-white border-gray-900'
+                    }`}
+                  >
+                    {isFollowing(u.userId) ? '팔로잉' : '팔로우'}
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+
+          {query.hasNextPage && (
+            <div className="flex justify-center py-4">
+              <button
+                onClick={() => query.fetchNextPage()}
+                disabled={query.isFetchingNextPage}
+                className="px-4 py-2 text-sm font-medium border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+              >
+                {query.isFetchingNextPage ? '불러오는 중...' : '더보기'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </NarrowPage>
+  );
+}
+```
+
+- [ ] **Step 2: 라우트 등록**
+
+`frontend/src/App.tsx` — 상단 import 추가(다른 페이지 import들과 같은 위치):
+```tsx
+import FollowListPage from './pages/follow/FollowListPage';
+```
+
+그리고 `AuthRoute` + `Layout` 안, `/profile` 라우트 바로 아래에 추가:
+```tsx
+            <Route path="/profile" element={<ProfilePage />} />
+            <Route path="/follow" element={<FollowListPage />} />
+```
+
+- [ ] **Step 3: 타입체크**
+
+Run: `cd frontend && npx tsc -b`
+Expected: 통과.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add frontend/src/pages/follow/FollowListPage.tsx frontend/src/App.tsx
+git commit -m "feat(follow): 팔로우 목록 페이지(팔로잉/팔로워 탭 + 더보기 + 언팔 토글) + 라우트"
+```
+
+---
+
+## Task 5: ProfilePage 헤더 팔로우 카운트 진입점
+
+**Files:**
+- Modify: `frontend/src/pages/profile/ProfilePage.tsx`
+
+현재 `ProfilePage.tsx:255-265`에 하드코딩 "팔로워 0 · 팔로잉 0" 블록이 있다. 이를 실데이터 + 클릭 링크로 교체한다.
+
+- [ ] **Step 1: import 추가**
+
+`frontend/src/pages/profile/ProfilePage.tsx` 상단 — `api/auth` import 줄 근처에 추가:
+```tsx
+import { fetchFollowCounts } from '../../api/follow';
+```
+(`useQuery`, `useNavigate`는 이미 import되어 있으므로 추가 불필요.)
+
+- [ ] **Step 2: 카운트 쿼리 추가**
+
+다른 `useQuery` 선언들 근처(예: `postsQuery` 위/아래, `ProfilePage.tsx:120` 영역)에 추가:
+```tsx
+  const followCountsQuery = useQuery({
+    queryKey: ['follow-counts'],
+    queryFn: fetchFollowCounts,
+    staleTime: 30_000,
+  });
+  const followCounts = followCountsQuery.data;
+```
+
+- [ ] **Step 3: 하드코딩 카운트 블록 교체**
+
+`ProfilePage.tsx:255-265`의 아래 블록을 찾는다:
+```tsx
+            {/* 팔로워/팔로잉 — 백엔드 대기, 0 표시 */}
+            <div className="flex gap-4 text-sm text-gray-500">
+              <span>
+                팔로워 <span className="font-medium text-gray-900">0</span>
+              </span>
+              <span>
+                팔로잉 <span className="font-medium text-gray-900">0</span>
+              </span>
+            </div>
+```
+다음으로 교체:
+```tsx
+            {/* 팔로워/팔로잉 — /me/follow-counts, 클릭 시 목록 페이지 진입 */}
+            <div className="flex gap-4 text-sm text-gray-500">
+              <button
+                onClick={() => navigate('/follow?tab=followers')}
+                className="hover:text-gray-900 transition-colors"
+              >
+                팔로워{' '}
+                <span className="font-medium text-gray-900">
+                  {followCounts?.followerCount ?? 0}
+                </span>
+              </button>
+              <button
+                onClick={() => navigate('/follow?tab=followings')}
+                className="hover:text-gray-900 transition-colors"
+              >
+                팔로잉{' '}
+                <span className="font-medium text-gray-900">
+                  {followCounts?.followingCount ?? 0}
+                </span>
+              </button>
+            </div>
+```
+
+- [ ] **Step 4: 타입체크**
+
+Run: `cd frontend && npx tsc -b`
+Expected: 통과.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add frontend/src/pages/profile/ProfilePage.tsx
+git commit -m "feat(follow): ProfilePage 헤더 팔로우 카운트 실데이터+목록 진입"
+```
+
+---
+
+## Task 6: 브라우저 수동 검증 (2계정 + 시드)
+
+**Files:** 없음(수동 검증)
+
+이 프로젝트는 단위 테스트가 없으므로 실제 화면으로 검증한다. 백엔드는 staging을 쓴다(`api-staging.melonnetherapists.com`).
+
+- [ ] **Step 1: 시드 — 계정 B가 계정 A를 팔로우**
+
+방법: 계정 B로 로그인한 상태의 토큰으로 Swagger UI(`https://api-staging.melonnetherapists.com/swagger-ui/index.html`) 또는 curl로 `POST /api/v1/users/{A의 userId}/follow` 호출. (A를 팔로우하는 사람을 1명 만들고, A가 누군가를 팔로우한 상태도 1건 만들면 양 탭 모두 데이터가 보인다.)
+
+- [ ] **Step 2: dev 서버 기동**
+
+Run: `cd frontend && npm run dev`
+Expected: Vite dev 서버 기동, 브라우저로 접속.
+
+- [ ] **Step 3: 검증 체크리스트 (계정 A로 로그인)**
+
+- [ ] `/profile` 헤더에 "팔로워 N · 팔로잉 N"이 0이 아닌 실제 수로 표시
+- [ ] "팔로워" 숫자 클릭 → `/follow?tab=followers` 진입, 나를 팔로우한 사람 명단(사진+닉네임+역할), **버튼 없음**
+- [ ] "팔로잉" 숫자 클릭 → `/follow?tab=followings` 진입, 내가 팔로우한 사람 + 각 행 "팔로잉" 버튼
+- [ ] 팔로잉 탭에서 "팔로잉" 클릭 → 즉시 "팔로우"로 flip(낙관적), 잠시 후 유지(서버 성공) → ProfilePage 재진입 시 팔로잉 카운트 1 감소
+- [ ] "팔로우"(재팔로우) 클릭 → "팔로잉"으로 복귀
+- [ ] 탭 전환 시 URL `?tab=` 변경, 새로고침해도 같은 탭 유지
+- [ ] 목록이 PAGE_SIZE(10) 초과면 하단 "더보기" 노출, 클릭 시 다음 페이지 append
+- [ ] (실패 경로) 네트워크 끊고 토글 → "팔로잉" 라벨 롤백 + 에러 토스트
+
+- [ ] **Step 4: 최종 타입체크 + 빌드**
+
+Run: `cd frontend && npx tsc -b`
+Expected: 통과.
+
+---
+
+## Task 7: PR 생성
+
+- [ ] **Step 1: 푸시 + PR (사용자 승인 후)**
+
+> 외부 push는 사용자 승인 필요(메모리 규칙). 승인되면:
+```bash
+git push -u origin feat/follow-list
+gh pr create --base develop --title "feat(follow): 팔로우 목록 페이지 + 언팔로우 토글" --body "..."
+```
+
+---
+
+## 자기 검토 (작성자 체크 완료)
+
+- **스펙 커버리지:** §1 범위(목록 2탭/팔로잉 토글/팔로워 명단/카운트 진입) → Task 4·5. §2 API → Task 2. §4 토글 → Task 3. §5 페이지 → Task 4. §6 캐시 동기화(`invalidate ['follow-counts']`) → Task 3 Step 1. §7 에러처리(토스트/재시도/빈상태) → Task 3·4. §8 검증 → Task 6. 제외 항목(맞팔 버튼/피드 탭/카드 버튼)은 의도적 미포함, backlog F-12 기록 완료.
+- **플레이스홀더:** 없음. 모든 코드 블록 완전.
+- **타입 일관성:** `FollowUser`/`FollowStatus`/`FollowCount`/`PagedFollowUsers`(Task1) ↔ api(Task2) ↔ hook(Task3, `FollowUser`/`toggle`/`isFollowing`/`pendingId`) ↔ page(Task4) 시그니처 일치. `fetchFollowCounts`(Task2) ↔ ProfilePage(Task5) 일치. queryKey `['follow-counts']`(Task3 invalidate ↔ Task5 useQuery) 일치. `['follow', tab]`(Task4) 단일 사용.

--- a/docs/superpowers/specs/2026-06-08-follow-list-toggle-design.md
+++ b/docs/superpowers/specs/2026-06-08-follow-list-toggle-design.md
@@ -1,0 +1,148 @@
+# 팔로우 — 수직 슬라이스 1: 팔로우 목록 페이지 + 언팔로우 토글
+
+작성일: 2026-06-08
+상태: 설계 확정 (구현 대기)
+관련 메모리: `project_follow_feature`, backlog `B-04`
+재개 트리거: 「팔로우 이어가자」
+
+---
+
+## 1. 배경 & 범위
+
+백엔드 팔로우 API 7종이 staging Swagger에 등재 완료(2026-06-08 실조회 확인). 이번 작업은 팔로우 기능의 **첫 수직 슬라이스 하나**를 end-to-end로 동작·검증 가능하게 만드는 것이다.
+
+성공기준: 2개 계정 + 시드 1건으로 "팔로우 목록을 보고, 언팔로우가 눌리고 화면·카운트에 즉시 반영되는" 한 흐름이 실제로 동작한다.
+
+### 이번 슬라이스에 들어가는 것
+- `/follow` 페이지 — 탭 2개(팔로워 / 팔로잉)
+  - **팔로잉 탭**: 내가 팔로우한 유저 세로 나열(사진+닉네임+역할) + 행마다 "언팔로우" 토글 버튼(낙관적 업데이트 + 응답 reconcile + 실패 롤백)
+  - **팔로워 탭**: 나를 팔로우한 유저 세로 나열 — 명단 표시만(이번엔 버튼 없음)
+  - 두 탭 모두 "더보기" 버튼 방식 페이지네이션(offset)
+- 진입점: `ProfilePage` 헤더에 "팔로워 N · 팔로잉 N" 카운트 표시 → 클릭 시 `/follow?tab=...`
+
+### 이번 슬라이스에서 제외 (백로그)
+1. **팔로워 탭 맞팔(follow-back) 버튼** — `FollowUserResponse`에 "내가 이 사람을 팔로우 중인가"(`following`) 필드가 없어 행 버튼의 초기 라벨을 정확히 그릴 수 없음. 1차 팔로우 기능 안정화 후 BE에 `FollowUserResponse.following` 필드 추가를 요청하고 정확한 라벨로 붙인다. (쪽지 `F-10`과 동일한 "응답에 필드 1개 추가" 패턴)
+2. **홈피드 "팔로우" 탭 배선**(`/posts/feed/following`, 커서) — 별도 슬라이스(접근 B). `useInfiniteFeed`(Hot Path) 일반화 동반이라 분리.
+3. **피드 카드 / 타인 프로필에서의 팔로우 버튼** — 피드 아이템(`TherapyPostSummaryResponse`)·`PostSummary`에 `authorId` 없음 + 타인 프로필(B-09 `GET /users/{id}`) 부재로 BE 블로킹.
+
+---
+
+## 2. API 계약 (staging Swagger 실조회, 2026-06-08)
+
+모든 응답은 `ApiResponse` envelope(`{success, data}`). 응답 인터셉터(`api/axiosInstance.ts:35-40`)가 `success===true`면 `data`로 언랩한다. follow API는 방어적으로 `res.data?.data ?? res.data`를 쓴다(최신 형제 모듈 `api/messages.ts` 패턴).
+
+| 엔드포인트 | 메서드 | 파라미터 | 응답(언랩 후) |
+|---|---|---|---|
+| `/api/v1/me/follow-counts` | GET | — | `FollowCountResponse` |
+| `/api/v1/me/followings` | GET | `page`(기본0), `size`(기본10) | `PagedResponseFollowUserResponse` |
+| `/api/v1/me/followers` | GET | `page`(기본0), `size`(기본10) | `PagedResponseFollowUserResponse` |
+| `/api/v1/users/{userId}/follow` | GET | path `userId` | `FollowStatusResponse` |
+| `/api/v1/users/{userId}/follow` | POST | path `userId` | `FollowStatusResponse` |
+| `/api/v1/users/{userId}/follow` | DELETE | path `userId` | `FollowStatusResponse` |
+
+스키마 필드:
+- `FollowCountResponse` = `{ followerCount: number, followingCount: number }`
+- `FollowUserResponse` = `{ userId: number, nickname: string, profileImageUrl: string, role: string }` — **`following` 필드 없음**(§1 제외 1번 근거)
+- `FollowStatusResponse` = `{ userId: number, following: boolean }`
+- `PagedResponseFollowUserResponse` = `{ items: FollowUserResponse[], page, size, totalElements, totalPages, hasNext }`
+
+> 페이지네이션 형태 주의: 목록 두 종은 **offset**(`page`/`size` + `totalPages`/`hasNext`)이다. 커서가 아니므로 자동 무한스크롤이 아닌 "더보기" 방식을 쓴다. (커서 방식은 홈피드 `/posts/feed/following` 쪽으로, 이번 범위 밖)
+
+---
+
+## 3. 파일 구성
+
+### 신규
+- **`src/types/follow.ts`**
+  - `FollowUser` = `{ userId, nickname, profileImageUrl?: string | null, role: string }`
+  - `FollowStatus` = `{ userId, following: boolean }`
+  - `FollowCount` = `{ followerCount, followingCount }`
+  - `PagedFollowUsers` = `{ items: FollowUser[], page, size, totalElements, totalPages, hasNext }`
+- **`src/api/follow.ts`**
+  - `fetchFollowCounts(): Promise<FollowCount>`
+  - `fetchFollowings(page?, size?): Promise<PagedFollowUsers>`
+  - `fetchFollowers(page?, size?): Promise<PagedFollowUsers>`
+  - `getFollowStatus(userId): Promise<FollowStatus>` (이번 슬라이스 미사용이나 토대로 같이 정의 — 백로그 맞팔 버튼에서 사용 예정. **YAGNI 판단: 토글에 직접 필요 없으면 작성 보류 가능, 구현 단계에서 결정**)
+  - `followUser(userId): Promise<FollowStatus>` (POST)
+  - `unfollowUser(userId): Promise<FollowStatus>` (DELETE)
+  - 모두 `res.data?.data ?? res.data` 언랩.
+- **`src/hooks/useFollowToggle.ts`** — 행 단위 낙관적 언팔/팔로우 토글. §4 참조.
+- **`src/pages/follow/FollowListPage.tsx`** — `/follow` 페이지. §5 참조.
+
+### 변경
+- **`src/App.tsx`** — `AuthRoute` + `Layout` 블록 안(`/profile` 라우트 옆)에 `<Route path="/follow" element={<FollowListPage />} />` 추가.
+- **`src/pages/profile/ProfilePage.tsx`** — 프로필 정보 블록에 "팔로워 N · 팔로잉 N" 카운트 추가. `useQuery(['follow-counts'], fetchFollowCounts)`로 조회, 각 숫자 클릭 시 `navigate('/follow?tab=followers'|'followings')`.
+
+---
+
+## 4. 토글 훅 — `useFollowToggle`
+
+댓글 리액션 B패턴(`hooks/useCommentReactionToggle.ts`)을 목록 행에 맞게 변형한다.
+
+- 입력: 현재 목록 `users: FollowUser[]` + `setUsers(next)` (페이지 레벨 단일 진실 소스).
+- 단일 in-flight 가드: `togglingId` 상태로 한 번에 한 행만 처리.
+- 동작(팔로잉 탭의 언팔로우 기준):
+  1. 롤백용 원본 보관.
+  2. 낙관적 반영 — 해당 유저를 목록에서 제거하지 않고, "언팔로우됨" 상태로 표시(버튼 라벨이 "팔로우"로 flip). 행은 유지(재팔로우 가능, 갑작스런 제거로 인한 점프 방지).
+  3. `unfollowUser(userId)` 호출 → 응답 `FollowStatus.following`으로 reconcile.
+  4. 실패 시 원본 롤백 + `toast.error(...)`(sonner, 프로젝트 전역 사용 중) + `console.error('[follow]', err)`.
+- 행의 팔로우 상태를 어떻게 보관할지: `FollowUser`엔 `following`이 없으므로, 훅 내부에서 행별 토글 상태를 별도 맵(`Record<userId, boolean>`)으로 관리하거나, 표시용 로컬 뷰모델에 `following` 필드를 덧입힌다. 구현 단계에서 둘 중 단순한 쪽 선택.
+
+> 팔로잉 탭은 로드 시점 전원 `following=true`(정의상 내가 팔로우한 사람). 따라서 초기 라벨은 항상 정확. 토글은 true→false(언팔)→true(재팔로우)만 오간다.
+
+---
+
+## 5. 페이지 — `FollowListPage`
+
+- 래퍼: `NarrowPage`(640px) + `PageHeader`(← 뒤로, 제목 "팔로우").
+- 탭: URL `?tab=followers|followings`(기본 `followings`). 탭 전환 시 searchParams 갱신(쪽지함 탭 URL 보존 패턴과 동일 결).
+- 목록 데이터: 탭별 RQ `useInfiniteQuery`
+  - queryKey: `['follow', tab]`
+  - pageParam = 페이지 인덱스(0부터), `initialPageParam: 0`
+  - `getNextPageParam: (lastPage) => lastPage.hasNext ? lastPage.page + 1 : undefined`
+  - queryFn: `tab==='followings' ? fetchFollowings(pageParam) : fetchFollowers(pageParam)`
+  - 펼친 items = `data.pages.flatMap(p => p.items)`
+- "더보기" 버튼: `hasNextPage`일 때 하단 노출, 클릭 시 `fetchNextPage()`. (자동 무한스크롤·IntersectionObserver 미사용)
+- 행 렌더: `UserAvatar`(size sm/md) + 닉네임 + 역할 배지(`role`) + (팔로잉 탭만) 우측 토글 버튼.
+- 빈 상태:
+  - 팔로잉 탭: "아직 팔로우한 치료사가 없어요"
+  - 팔로워 탭: "아직 나를 팔로우한 사람이 없어요"
+- 로딩: 스켈레톤 행 또는 기존 Skeleton 컴포넌트 재사용.
+
+---
+
+## 6. 데이터 흐름 / 캐시 동기화
+
+- 카운트: `useQuery(['follow-counts'], fetchFollowCounts)` — ProfilePage 헤더.
+- 목록: `useInfiniteQuery(['follow', tab])` — FollowListPage.
+- 언팔 토글 성공 후: `queryClient.invalidateQueries({ queryKey: ['follow-counts'] })`로 카운트 동기화. 목록은 페이지 레벨 상태가 이미 reconcile됨(행 유지). 필요 시 `['follow','followings']`도 invalidate 고려하나, 행 유지 정책상 즉시 refetch는 불필요(과도한 깜빡임 회피).
+
+---
+
+## 7. 에러 처리 / 엣지
+
+- 토글 실패 → 낙관적 롤백 + `toast.error` + `[follow]` 로깅.
+- 목록 fetch 실패 → 에러 문구 + "재시도" 버튼(`refetch`).
+- 카운트 fetch 실패 → 헤더 카운트 자리 숨김 또는 "–" 표시(진입은 가능하게 유지).
+- 비로그인 접근 → `AuthRoute`가 차단(라우트가 AuthRoute 안).
+
+---
+
+## 8. 검증
+
+- 2계정 + 시드: 계정 B가 계정 A를 팔로우(Swagger POST로 시드).
+- A 로그인 → ProfilePage 헤더 "팔로워 1 · 팔로잉 N" 표시 확인.
+- 카운트 클릭 → `/follow` 해당 탭 진입.
+- 팔로잉 탭: 내가 팔로우한 유저 나열 → "언팔로우" 클릭 → 즉시 라벨 flip(낙관적) → 성공 시 유지, 강제 실패 주입 시 롤백 + 토스트.
+- 카운트가 언팔 후 갱신되는지(헤더 재진입 또는 invalidate 반영).
+- "더보기" 버튼으로 다음 페이지 append(목록이 size 초과일 때).
+- 팔로워 탭: 명단 표시(버튼 없음) 확인.
+- 탭 전환 + URL `?tab=` 보존.
+- `tsc -b` 통과.
+
+---
+
+## 9. 백로그 반영 항목
+
+- **팔로워 탭 맞팔 버튼 + BE `FollowUserResponse.following` 필드 요청** — 1차 안정화 후. (backlog 신규 항목)
+- **홈피드 팔로우 탭 배선(접근 B)** — 기존 backlog `B-04` 후속.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import MessageBoxPage from './pages/message/MessageBoxPage';
 import MessageDetailPage from './pages/message/MessageDetailPage';
 import SearchPage from './pages/search/SearchPage';
 import ProfilePage from './pages/profile/ProfilePage';
+import FollowListPage from './pages/follow/FollowListPage';
 import NotificationPage from './pages/notification/NotificationPage';
 import TherapistVerificationPage from './pages/auth/TherapistVerificationPage';
 import VerificationCompletePage from './pages/auth/VerificationCompletePage';
@@ -84,6 +85,7 @@ function App() {
             <Route path="/search" element={<SearchPage />} />
             <Route path="/notifications" element={<NotificationPage />} />
             <Route path="/profile" element={<ProfilePage />} />
+            <Route path="/follow" element={<FollowListPage />} />
             {/* 쪽지함(받은/보낸 2탭). 상세는 /messages/:messageId */}
             <Route path="/messages" element={<MessageBoxPage />} />
             {/* 모바일 쪽지 작성. 정적 경로라 /messages/:messageId보다 먼저 배치 */}

--- a/frontend/src/api/follow.ts
+++ b/frontend/src/api/follow.ts
@@ -18,6 +18,11 @@ export async function fetchFollowers(page = 0, size = 10): Promise<PagedFollowUs
   return res.data?.data ?? res.data;
 }
 
+export async function getFollowStatus(userId: number): Promise<FollowStatus> {
+  const res = await axiosInstance.get(`/users/${userId}/follow`);
+  return res.data?.data ?? res.data;
+}
+
 export async function followUser(userId: number): Promise<FollowStatus> {
   const res = await axiosInstance.post(`/users/${userId}/follow`);
   return res.data?.data ?? res.data;

--- a/frontend/src/api/follow.ts
+++ b/frontend/src/api/follow.ts
@@ -1,0 +1,29 @@
+import axiosInstance from './axiosInstance';
+import type { FollowCount, PagedFollowUsers, FollowStatus } from '../types/follow';
+
+// 응답 인터셉터(axiosInstance.ts:35-40)가 {success,data}를 data로 언랩하지만,
+// 최신 형제 모듈(api/messages.ts)과 동일하게 방어적으로 한 번 더 언랩한다.
+export async function fetchFollowCounts(): Promise<FollowCount> {
+  const res = await axiosInstance.get('/me/follow-counts');
+  return res.data?.data ?? res.data;
+}
+
+export async function fetchFollowings(page = 0, size = 10): Promise<PagedFollowUsers> {
+  const res = await axiosInstance.get('/me/followings', { params: { page, size } });
+  return res.data?.data ?? res.data;
+}
+
+export async function fetchFollowers(page = 0, size = 10): Promise<PagedFollowUsers> {
+  const res = await axiosInstance.get('/me/followers', { params: { page, size } });
+  return res.data?.data ?? res.data;
+}
+
+export async function followUser(userId: number): Promise<FollowStatus> {
+  const res = await axiosInstance.post(`/users/${userId}/follow`);
+  return res.data?.data ?? res.data;
+}
+
+export async function unfollowUser(userId: number): Promise<FollowStatus> {
+  const res = await axiosInstance.delete(`/users/${userId}/follow`);
+  return res.data?.data ?? res.data;
+}

--- a/frontend/src/components/common/UserActionDropdown.tsx
+++ b/frontend/src/components/common/UserActionDropdown.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { User, UserPlus, UserCheck, Mail } from 'lucide-react';
 import UserAvatar from './UserAvatar';
 import { useAuthStore } from '../../stores/useAuthStore';
 import { useFollowUser } from '../../hooks/useFollowUser';
@@ -45,15 +46,32 @@ function UserActionDropdown({
           onClick={() => toast('준비 중인 기능이에요', { id: 'coming-soon' })}
           className="text-gray-400"
         >
+          <User size={14} className="mr-2" />
           프로필
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() => follow.toggle()}
           disabled={follow.isLoading || follow.pending}
+          className={follow.following ? 'text-gray-400' : ''}
         >
-          {follow.isLoading ? '불러오는 중…' : follow.following ? '팔로잉' : '팔로우'}
+          {follow.isLoading ? (
+            '불러오는 중…'
+          ) : follow.following ? (
+            <>
+              <UserCheck size={14} className="mr-2" />
+              팔로잉
+            </>
+          ) : (
+            <>
+              <UserPlus size={14} className="mr-2" />
+              팔로우
+            </>
+          )}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => onMessageClick?.()}>쪽지</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => onMessageClick?.()}>
+          <Mail size={14} className="mr-2" />
+          쪽지
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/frontend/src/components/common/UserActionDropdown.tsx
+++ b/frontend/src/components/common/UserActionDropdown.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import UserAvatar from './UserAvatar';
 import { useAuthStore } from '../../stores/useAuthStore';
+import { useFollowUser } from '../../hooks/useFollowUser';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -24,13 +26,17 @@ function UserActionDropdown({
   onMessageClick,
 }: UserActionDropdownProps) {
   const myId = useAuthStore((s) => s.user?.id);
+  // 드롭다운이 열렸을 때만 팔로우 상태를 조회한다(닫혀 있으면 호출 안 함).
+  const [open, setOpen] = useState(false);
+  const follow = useFollowUser(targetUserId, open);
 
+  // 본인이면 메뉴 없이 아바타만 (hooks는 위에서 무조건 호출되어 순서 보장).
   if (targetUserId === myId) {
     return <UserAvatar nickname={nickname} imageUrl={imageUrl} size={size} />;
   }
 
   return (
-    <DropdownMenu modal={false}>
+    <DropdownMenu modal={false} open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger aria-label={`${nickname}님 메뉴`} onClick={(e) => e.stopPropagation()}>
         <UserAvatar nickname={nickname} imageUrl={imageUrl} size={size} />
       </DropdownMenuTrigger>
@@ -42,10 +48,10 @@ function UserActionDropdown({
           프로필
         </DropdownMenuItem>
         <DropdownMenuItem
-          onClick={() => toast('준비 중인 기능이에요', { id: 'coming-soon' })}
-          className="text-gray-400"
+          onClick={() => follow.toggle()}
+          disabled={follow.isLoading || follow.pending}
         >
-          팔로우
+          {follow.isLoading ? '불러오는 중…' : follow.following ? '팔로잉' : '팔로우'}
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => onMessageClick?.()}>쪽지</DropdownMenuItem>
       </DropdownMenuContent>

--- a/frontend/src/components/common/UserAvatar.tsx
+++ b/frontend/src/components/common/UserAvatar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { resolveImageUrl } from '../../utils/resolveImageUrl';
 
 interface UserAvatarProps {
@@ -16,12 +17,16 @@ const sizeMap = {
 export default function UserAvatar({ nickname, imageUrl, size = 'sm' }: UserAvatarProps) {
   const resolved = resolveImageUrl(imageUrl);
   const { container, text } = sizeMap[size];
+  // 이미지 로드 실패(예: BE가 presigned 대신 raw S3 키를 내려준 경우) 시 이니셜로 폴백.
+  // 실패한 src 자체를 기억해, src가 바뀌면(다른 유저) 자연히 다시 시도한다.
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
 
-  if (resolved) {
+  if (resolved && resolved !== failedSrc) {
     return (
       <img
         src={resolved}
         alt={nickname}
+        onError={() => setFailedSrc(resolved)}
         className={`${container} rounded-full object-cover shrink-0`}
       />
     );

--- a/frontend/src/hooks/useFollowToggle.ts
+++ b/frontend/src/hooks/useFollowToggle.ts
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
+import { followUser, unfollowUser } from '../api/follow';
+import type { FollowUser } from '../types/follow';
+
+// 팔로잉 탭 행 단위 낙관적 팔로우/언팔 토글.
+// 댓글 리액션 B패턴(useCommentReactionToggle)을 목록 행에 맞게 변형.
+export function useFollowToggle() {
+  const qc = useQueryClient();
+  // 이번 세션에서 언팔된 userId 집합. 비어있음 = 전원 팔로잉(팔로잉 탭 초기 상태).
+  const [unfollowed, setUnfollowed] = useState<Set<number>>(new Set());
+  const [pendingId, setPendingId] = useState<number | null>(null);
+
+  const isFollowing = (userId: number) => !unfollowed.has(userId);
+
+  function applyUnfollow(userId: number, shouldUnfollow: boolean) {
+    setUnfollowed((prev) => {
+      const next = new Set(prev);
+      if (shouldUnfollow) next.add(userId);
+      else next.delete(userId);
+      return next;
+    });
+  }
+
+  async function toggle(user: FollowUser) {
+    if (pendingId !== null) return; // 한 번에 한 행만
+    const userId = user.userId;
+    const currentlyFollowing = isFollowing(userId);
+    setPendingId(userId);
+
+    // 낙관적 반영: 팔로잉이면 언팔, 아니면 재팔로우
+    applyUnfollow(userId, currentlyFollowing);
+
+    try {
+      const fresh = currentlyFollowing
+        ? await unfollowUser(userId)
+        : await followUser(userId);
+      // 서버 응답으로 reconcile (following=false → 언팔 상태로 고정)
+      applyUnfollow(userId, !fresh.following);
+      qc.invalidateQueries({ queryKey: ['follow-counts'] });
+    } catch (err) {
+      // 롤백: 낙관적 반영을 되돌림
+      applyUnfollow(userId, !currentlyFollowing);
+      console.error('[follow]', err);
+      toast.error('처리에 실패했어요. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  return { isFollowing, toggle, pendingId };
+}

--- a/frontend/src/hooks/useFollowUser.ts
+++ b/frontend/src/hooks/useFollowUser.ts
@@ -26,10 +26,11 @@ export function useFollowUser(targetUserId: number, enabled: boolean) {
       const fresh = wasFollowing
         ? await unfollowUser(targetUserId)
         : await followUser(targetUserId);
-      // 단일 상태 캐시 갱신 + 카운트/목록 동기화
+      // 단일 상태 캐시 갱신 + 카운트 동기화.
+      // 목록(['follow'])은 강제 무효화하지 않는다 — 정책 A(언팔해도 행 유지) 일관성.
+      // 목록 경로(useFollowToggle)도 카운트만 동기화하므로 두 경로를 동일하게 맞춤.
       qc.setQueryData(['follow-status', targetUserId], fresh);
       qc.invalidateQueries({ queryKey: ['follow-counts'] });
-      qc.invalidateQueries({ queryKey: ['follow'] });
       toast(fresh.following ? '팔로우했어요' : '팔로우를 취소했어요');
     } catch (err) {
       console.error('[follow]', err);

--- a/frontend/src/hooks/useFollowUser.ts
+++ b/frontend/src/hooks/useFollowUser.ts
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getFollowStatus, followUser, unfollowUser } from '../api/follow';
+
+// 단일 유저 팔로우 상태 + 토글 (게시글 상세/댓글 작성자 드롭다운용).
+// 상태 조회는 enabled일 때만(드롭다운이 열렸을 때만) 호출 → 댓글 N개여도 연 것만 요청.
+export function useFollowUser(targetUserId: number, enabled: boolean) {
+  const qc = useQueryClient();
+  const [pending, setPending] = useState(false);
+
+  const statusQuery = useQuery({
+    queryKey: ['follow-status', targetUserId],
+    queryFn: () => getFollowStatus(targetUserId),
+    enabled,
+    staleTime: 30_000,
+  });
+
+  const following = statusQuery.data?.following ?? false;
+
+  async function toggle() {
+    if (pending) return;
+    setPending(true);
+    const wasFollowing = following;
+    try {
+      const fresh = wasFollowing
+        ? await unfollowUser(targetUserId)
+        : await followUser(targetUserId);
+      // 단일 상태 캐시 갱신 + 카운트/목록 동기화
+      qc.setQueryData(['follow-status', targetUserId], fresh);
+      qc.invalidateQueries({ queryKey: ['follow-counts'] });
+      qc.invalidateQueries({ queryKey: ['follow'] });
+      toast(fresh.following ? '팔로우했어요' : '팔로우를 취소했어요');
+    } catch (err) {
+      console.error('[follow]', err);
+      toast.error('처리에 실패했어요. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return { following, isLoading: statusQuery.isLoading, toggle, pending };
+}

--- a/frontend/src/hooks/useNotificationSSE.ts
+++ b/frontend/src/hooks/useNotificationSSE.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '../stores/useAuthStore';
 import { useNotificationStore } from '../stores/useNotificationStore';
 import { useMessageStore } from '../stores/useMessageStore';
@@ -26,6 +27,7 @@ const BACKOFF_MULTIPLIER = 2;
  */
 export function useNotificationSSE() {
   const tokens = useAuthStore((s) => s.tokens);
+  const queryClient = useQueryClient();
 
   const store = useNotificationStore;
   const connectionRef = useRef<SseConnection | null>(null);
@@ -111,6 +113,12 @@ export function useNotificationSSE() {
             // 둘 다 오르는 건 의도된 동작 — 스펙 "알림/뱃지 동작" 참조.
             if (notification.type === 'NEW_MESSAGE') {
               useMessageStore.getState().increment();
+            }
+            // 누가 나를 팔로우 → 팔로워 카운트 서버 재조회로 보정.
+            // 언팔로우 알림은 enum에 없어(NEW_FOLLOW만) 낙관적 +1은 감소를 못 따라가 드리프트 →
+            // 무효화로 서버 진실에 맞춤(/me/follow-counts는 경량).
+            if (notification.type === 'NEW_FOLLOW') {
+              queryClient.invalidateQueries({ queryKey: ['follow-counts'] });
             }
             toast(notification.content, { duration: 4000 });
           } catch (err) {

--- a/frontend/src/pages/follow/FollowListPage.tsx
+++ b/frontend/src/pages/follow/FollowListPage.tsx
@@ -104,13 +104,21 @@ export default function FollowListPage() {
                   <button
                     onClick={() => toggle(u)}
                     disabled={pendingId === u.userId}
-                    className={`text-xs px-3 py-1.5 rounded-full border transition-colors disabled:opacity-50 ${
+                    className={`group w-[72px] text-center text-xs px-3 py-1.5 rounded-full border transition-colors disabled:opacity-50 ${
                       isFollowing(u.userId)
-                        ? 'text-gray-500 border-gray-300 hover:border-gray-400'
+                        ? 'text-gray-500 border-gray-300 hover:text-red-600 hover:border-red-300 hover:bg-red-50'
                         : 'bg-gray-900 text-white border-gray-900'
                     }`}
                   >
-                    {isFollowing(u.userId) ? '팔로잉' : '팔로우'}
+                    {isFollowing(u.userId) ? (
+                      <>
+                        {/* 기본 "팔로잉", 호버 시 빨간 "언팔로우"로 전환 — 실수 언팔 방지(의도 명확화) */}
+                        <span className="group-hover:hidden">팔로잉</span>
+                        <span className="hidden group-hover:inline">언팔로우</span>
+                      </>
+                    ) : (
+                      '팔로우'
+                    )}
                   </button>
                 )}
               </li>

--- a/frontend/src/pages/follow/FollowListPage.tsx
+++ b/frontend/src/pages/follow/FollowListPage.tsx
@@ -1,0 +1,135 @@
+import { useSearchParams } from 'react-router-dom';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import PageHeader from '../../components/common/PageHeader';
+import NarrowPage from '../../components/common/NarrowPage';
+import UserAvatar from '../../components/common/UserAvatar';
+import { fetchFollowings, fetchFollowers } from '../../api/follow';
+import { useFollowToggle } from '../../hooks/useFollowToggle';
+import type { FollowUser, PagedFollowUsers } from '../../types/follow';
+
+const PAGE_SIZE = 10;
+type Tab = 'followings' | 'followers';
+
+// role enum → 한국어 라벨. 미지의 값은 원문 노출(방어적).
+const ROLE_LABEL: Record<string, string> = {
+  THERAPIST: '치료사',
+  ADMIN: '관리자',
+  USER: '회원',
+};
+
+export default function FollowListPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab: Tab = searchParams.get('tab') === 'followers' ? 'followers' : 'followings';
+
+  const { isFollowing, toggle, pendingId } = useFollowToggle();
+
+  const query = useInfiniteQuery({
+    queryKey: ['follow', tab],
+    queryFn: ({ pageParam }) =>
+      tab === 'followings'
+        ? fetchFollowings(pageParam, PAGE_SIZE)
+        : fetchFollowers(pageParam, PAGE_SIZE),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage: PagedFollowUsers) =>
+      lastPage.hasNext ? lastPage.page + 1 : undefined,
+    staleTime: 30_000,
+  });
+
+  const users: FollowUser[] = query.data?.pages.flatMap((p) => p.items) ?? [];
+
+  function switchTab(next: Tab) {
+    if (next === tab) return;
+    setSearchParams({ tab: next });
+  }
+
+  return (
+    <NarrowPage>
+      <PageHeader title="팔로우" backTo="/profile" />
+
+      {/* 팔로잉/팔로워 탭 — 쪽지함과 동일 컨벤션 */}
+      <div className="sticky top-0 z-40 bg-white border-b border-gray-200">
+        <div className="flex">
+          {(
+            [
+              ['followings', '팔로잉'],
+              ['followers', '팔로워'],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              onClick={() => switchTab(value)}
+              className={`flex-1 py-2.5 text-xs font-medium text-center transition-colors ${
+                tab === value ? 'text-neutral-950 border-b-2 border-black' : 'text-gray-400'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {query.isLoading ? (
+        <div className="px-4 py-12 text-center text-gray-400 text-sm">불러오는 중...</div>
+      ) : query.isError ? (
+        <div className="flex flex-col items-center gap-3 py-12">
+          <p className="text-sm text-destructive">목록을 불러오지 못했어요.</p>
+          <button
+            onClick={() => query.refetch()}
+            className="px-4 py-2 text-sm font-medium border border-gray-300 rounded-lg hover:bg-gray-50"
+          >
+            재시도
+          </button>
+        </div>
+      ) : users.length === 0 ? (
+        <div className="px-4 py-12 text-center text-gray-400 text-sm">
+          {tab === 'followings'
+            ? '아직 팔로우한 치료사가 없어요'
+            : '아직 나를 팔로우한 사람이 없어요'}
+        </div>
+      ) : (
+        <>
+          <ul>
+            {users.map((u) => (
+              <li
+                key={u.userId}
+                className="flex items-center gap-3 px-4 py-3 border-b border-gray-100"
+              >
+                <UserAvatar nickname={u.nickname} imageUrl={u.profileImageUrl} size="md" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-900 truncate">{u.nickname}</p>
+                  <p className="text-xs text-gray-400">{ROLE_LABEL[u.role] ?? u.role}</p>
+                </div>
+                {/* 팔로잉 탭만 토글 버튼. 팔로워 탭은 명단 표시만(맞팔 버튼=backlog F-12) */}
+                {tab === 'followings' && (
+                  <button
+                    onClick={() => toggle(u)}
+                    disabled={pendingId === u.userId}
+                    className={`text-xs px-3 py-1.5 rounded-full border transition-colors disabled:opacity-50 ${
+                      isFollowing(u.userId)
+                        ? 'text-gray-500 border-gray-300 hover:border-gray-400'
+                        : 'bg-gray-900 text-white border-gray-900'
+                    }`}
+                  >
+                    {isFollowing(u.userId) ? '팔로잉' : '팔로우'}
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+
+          {query.hasNextPage && (
+            <div className="flex justify-center py-4">
+              <button
+                onClick={() => query.fetchNextPage()}
+                disabled={query.isFetchingNextPage}
+                className="px-4 py-2 text-sm font-medium border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+              >
+                {query.isFetchingNextPage ? '불러오는 중...' : '더보기'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </NarrowPage>
+  );
+}

--- a/frontend/src/pages/follow/FollowListPage.tsx
+++ b/frontend/src/pages/follow/FollowListPage.tsx
@@ -106,8 +106,8 @@ export default function FollowListPage() {
                     disabled={pendingId === u.userId}
                     className={`group w-[72px] text-center text-xs px-3 py-1.5 rounded-full border transition-colors disabled:opacity-50 ${
                       isFollowing(u.userId)
-                        ? 'text-gray-500 border-gray-300 hover:text-red-600 hover:border-red-300 hover:bg-red-50'
-                        : 'bg-gray-900 text-white border-gray-900'
+                        ? 'bg-gray-900 text-white border-gray-900 hover:bg-white hover:text-gray-700 hover:border-gray-300'
+                        : 'text-gray-500 border-gray-300 hover:border-gray-400'
                     }`}
                   >
                     {isFollowing(u.userId) ? (

--- a/frontend/src/pages/follow/FollowListPage.tsx
+++ b/frontend/src/pages/follow/FollowListPage.tsx
@@ -104,21 +104,14 @@ export default function FollowListPage() {
                   <button
                     onClick={() => toggle(u)}
                     disabled={pendingId === u.userId}
-                    className={`group w-[72px] text-center text-xs px-3 py-1.5 rounded-full border transition-colors disabled:opacity-50 ${
+                    className={`w-[72px] text-center text-xs px-3 py-1.5 rounded-full border transition-colors disabled:opacity-50 ${
                       isFollowing(u.userId)
-                        ? 'bg-gray-900 text-white border-gray-900 hover:bg-white hover:text-gray-700 hover:border-gray-300'
-                        : 'text-gray-500 border-gray-300 hover:border-gray-400'
+                        ? 'text-gray-600 border-gray-300 hover:border-gray-400 hover:text-gray-900'
+                        : 'bg-gray-900 text-white border-gray-900 hover:bg-gray-800'
                     }`}
                   >
-                    {isFollowing(u.userId) ? (
-                      <>
-                        {/* 기본 "팔로잉", 호버 시 빨간 "언팔로우"로 전환 — 실수 언팔 방지(의도 명확화) */}
-                        <span className="group-hover:hidden">팔로잉</span>
-                        <span className="hidden group-hover:inline">언팔로우</span>
-                      </>
-                    ) : (
-                      '팔로우'
-                    )}
+                    {/* 버튼이 클릭 시 일어날 동작을 그대로 표시 — 팔로우 중이면 "언팔로우", 언팔한 행이면 "팔로우" */}
+                    {isFollowing(u.userId) ? '언팔로우' : '팔로우'}
                   </button>
                 )}
               </li>

--- a/frontend/src/pages/profile/ProfilePage.tsx
+++ b/frontend/src/pages/profile/ProfilePage.tsx
@@ -7,6 +7,7 @@ import ProfileHeaderActions from '@/components/profile/ProfileHeaderActions';
 import PostCard from '../../components/post/PostCard';
 import { fetchMyPosts, fetchMyComments, fetchMyScraps } from '../../api/mypage';
 import { uploadProfileImage, updateMyProfile } from '../../api/auth';
+import { fetchFollowCounts } from '../../api/follow';
 import { useAuthStore } from '../../stores/useAuthStore';
 import type { MyComment } from '../../types/mypage';
 import type { PostSummary } from '../../types/post';
@@ -114,6 +115,13 @@ export default function ProfilePage() {
     queryClient.invalidateQueries({ queryKey: ['myComments'] });
     queryClient.invalidateQueries({ queryKey: ['myScraps'] });
   };
+
+  const followCountsQuery = useQuery({
+    queryKey: ['follow-counts'],
+    queryFn: fetchFollowCounts,
+    staleTime: 30_000,
+  });
+  const followCounts = followCountsQuery.data;
 
   const [postsPage, setPostsPage] = useState(1);
   const postsQuery = useQuery({
@@ -252,14 +260,26 @@ export default function ProfilePage() {
                 </>
               )}
             </div>
-            {/* 팔로워/팔로잉 — 백엔드 대기, 0 표시 */}
+            {/* 팔로워/팔로잉 — /me/follow-counts, 클릭 시 목록 페이지 진입 */}
             <div className="flex gap-4 text-sm text-gray-500">
-              <span>
-                팔로워 <span className="font-medium text-gray-900">0</span>
-              </span>
-              <span>
-                팔로잉 <span className="font-medium text-gray-900">0</span>
-              </span>
+              <button
+                onClick={() => navigate('/follow?tab=followers')}
+                className="hover:text-gray-900 transition-colors"
+              >
+                팔로워{' '}
+                <span className="font-medium text-gray-900">
+                  {followCounts?.followerCount ?? 0}
+                </span>
+              </button>
+              <button
+                onClick={() => navigate('/follow?tab=followings')}
+                className="hover:text-gray-900 transition-colors"
+              >
+                팔로잉{' '}
+                <span className="font-medium text-gray-900">
+                  {followCounts?.followingCount ?? 0}
+                </span>
+              </button>
             </div>
           </div>
         </div>

--- a/frontend/src/types/follow.ts
+++ b/frontend/src/types/follow.ts
@@ -1,0 +1,31 @@
+// 팔로우 목록 행 — /me/followings, /me/followers 공유 DTO.
+// 주의: 백엔드 FollowUserResponse에는 "내가 이 사람을 팔로우 중인가"(following) 필드가 없다.
+//       팔로워 탭 맞팔 버튼은 그래서 이번 슬라이스 제외(backlog F-12).
+export interface FollowUser {
+  userId: number;
+  nickname: string;
+  profileImageUrl?: string | null;
+  role: string;
+}
+
+// POST/DELETE/GET /users/{userId}/follow 응답.
+export interface FollowStatus {
+  userId: number;
+  following: boolean;
+}
+
+// GET /me/follow-counts 응답.
+export interface FollowCount {
+  followerCount: number;
+  followingCount: number;
+}
+
+// offset 페이지 응답 (커서 아님 — page/totalPages/hasNext).
+export interface PagedFollowUsers {
+  items: FollowUser[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  hasNext: boolean;
+}

--- a/frontend/src/types/notification.ts
+++ b/frontend/src/types/notification.ts
@@ -7,6 +7,7 @@ export type NotificationType =
   | 'VERIFICATION_SUBMITTED'
   | 'VERIFICATION_APPROVED'
   | 'VERIFICATION_REJECTED'
+  | 'NEW_FOLLOW'
   | 'NEW_MESSAGE';
 
 // 백엔드 NotificationResponse 스펙 (api-staging Swagger 기준).


### PR DESCRIPTION
## 개요
팔로우 기능 1차 수직 슬라이스. BE 7종 엔드포인트(2026-06-08 staging Swagger 확인) 위에 FE 구현.

설계/계획 문서: \`docs/superpowers/specs/2026-06-08-follow-list-toggle-design.md\`, \`docs/superpowers/plans/2026-06-08-follow-list-toggle.md\`

## 포함 범위
- **팔로우 목록 페이지** (\`/follow\`) — 팔로잉/팔로워 2탭, "더보기"(offset) 페이지네이션
  - 팔로잉 탭: 행별 **언팔로우 토글**(낙관적 + 응답 reconcile + 실패 롤백)
  - 팔로워 탭: 명단 표시(사진/닉네임/역할)
- **ProfilePage 헤더 팔로우 카운트** — \`/me/follow-counts\` 실데이터, 클릭 시 해당 탭 진입
- **작성자 드롭다운 팔로우 토글** — \`UserActionDropdown\`(게시글 상세 + 댓글 작성자)에서 팔로우/팔로잉, 드롭다운 열릴 때만 상태 조회. 본인 글은 가드로 제외

## 제외 (백로그 F-12)
- 팔로워 탭 맞팔 버튼 — \`FollowUserResponse\`에 \`following\` 필드 부재로 초기 라벨 부정확. 1차 안정화 후 BE 필드 추가 요청 예정
- 홈피드 "팔로우" 탭 배선(\`/posts/feed/following\`) — 별도 슬라이스

## 검증
- \`tsc -b\` 통과
- ⚠️ **브라우저 런타임 검증 미완** — 머지 전 staging/dev에서 2계정 시드로 팔로우/언팔/카운트/페이지네이션 확인 권장

## 신규 파일
\`types/follow.ts\` · \`api/follow.ts\` · \`hooks/useFollowToggle.ts\` · \`hooks/useFollowUser.ts\` · \`pages/follow/FollowListPage.tsx\`
변경: \`App.tsx\` · \`ProfilePage.tsx\` · \`UserActionDropdown.tsx\`