### PR TITLE
feat(feed): 홈피드 팔로우 탭 무한스크롤 배선 + 상세 뒤로가기 진입 출처 보존

### DIFF
--- a/frontend/src/api/posts.ts
+++ b/frontend/src/api/posts.ts
@@ -45,6 +45,19 @@ export async function fetchFeed(params: {
   return res.data?.data ?? res.data;
 }
 
+// 팔로우 피드 — fetchFeed 미러. 단 sort 없음(BE 미지원), postType만 선택.
+// 응답 shape은 전체 피드와 동일한 CursorPagedPosts.
+export async function fetchFollowingFeed(params: {
+  cursor?: string;
+  size?: number;
+  postType?: PostType;
+  signal?: AbortSignal;
+}): Promise<CursorPagedPosts> {
+  const { signal, ...query } = params;
+  const res = await axiosInstance.get('/posts/feed/following', { params: query, signal });
+  return res.data?.data ?? res.data;
+}
+
 export async function fetchPost(postId: number): Promise<PostDetail> {
   const res = await axiosInstance.get(`/posts/${postId}`);
   return res.data;

--- a/frontend/src/components/post/PostCard.tsx
+++ b/frontend/src/components/post/PostCard.tsx
@@ -15,9 +15,11 @@ import ConcernCard from './ConcernCard';
 interface PostCardProps {
   post: PostSummary;
   onReactionUpdated?: (fresh: PostReaction) => void;
+  // 상세 진입 후 뒤로가기로 돌아올 목적지(쿼리 포함). 미전달 시 상세는 '/posts' 폴백 → 기존 동작 유지.
+  backTo?: string;
 }
 
-export default function PostCard({ post, onReactionUpdated }: PostCardProps) {
+export default function PostCard({ post, onReactionUpdated, backTo }: PostCardProps) {
   const [scrapped, setScrapped] = useState(post.scrapped ?? false);
   const [scrapLoading, setScrapLoading] = useState(false);
 
@@ -78,6 +80,7 @@ export default function PostCard({ post, onReactionUpdated }: PostCardProps) {
   return (
     <Link
       to={post.accessLocked ? '/therapist-verifications' : `/posts/${post.id}`}
+      state={backTo ? { from: backTo } : undefined}
       draggable={false}
       className="block"
     >

--- a/frontend/src/hooks/useInfiniteFeed.ts
+++ b/frontend/src/hooks/useInfiniteFeed.ts
@@ -1,14 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { fetchFeed } from '../api/posts';
-import type { PostSummary } from '../types/post';
+import { useInfiniteQuery, type QueryKey } from '@tanstack/react-query';
+import type { CursorPagedPosts, PostSummary } from '../types/post';
 
 // useInfiniteFeed훅의 파라미터 타입 인터페이스
 // (R-01b 마이그레이션 전/후 동일 — PostListPage 호출부 변경 없음)
 interface UseInfiniteFeedOptions {
-  size?: number;
-  enabled?: boolean; // 무한 스크롤 모드 ON/OFF (필터/팔로잉 탭에서는 false → 페이지네이션 모드)
-  sort?: 'LATEST' | 'POPULAR';
+  // 캐시 주소 — 호출부가 직접 만든다. 전체 피드 ['feed',{size,sort}] / 팔로우 ['feed-following',{size}]
+  queryKey: QueryKey;
+  // 한 페이지를 가져오는 함수 — 호출부가 size/sort/postType 등을 클로저로 닫아 주입한다.
+  // pageParam(=cursor)과 RQ가 만든 signal을 받아 CursorPagedPosts를 반환.
+  fetchPage: (ctx: { pageParam: string | null; signal: AbortSignal }) => Promise<CursorPagedPosts>;
+  enabled?: boolean; // 무한 스크롤 모드 ON/OFF (필터/페이지네이션 모드에서는 false)
   initialSnapshot?: {
     // 뒤로가기 시 Zustand에 저장된 상태 복원용 (스크롤 위치 + 이미 로드된 아이템들)
     items: PostSummary[];
@@ -43,8 +45,8 @@ interface UseInfiniteFeedResult {
  *   }
  * 항상 pages.length === pageParams.length 불변량을 지킵니다.
  */
-export function useInfiniteFeed(options: UseInfiniteFeedOptions = {}): UseInfiniteFeedResult {
-  const { size = 20, enabled = true, sort = 'LATEST', initialSnapshot } = options;
+export function useInfiniteFeed(options: UseInfiniteFeedOptions): UseInfiniteFeedResult {
+  const { queryKey, fetchPage, enabled = true, initialSnapshot } = options;
 
   // onError 콜백을 ref로 보관합니다.
   // 이유: RQ v5에서 useQuery의 onError 옵션이 제거되었습니다.
@@ -73,19 +75,13 @@ export function useInfiniteFeed(options: UseInfiniteFeedOptions = {}): UseInfini
   }, [initialSnapshot]);
 
   const query = useInfiniteQuery({
-    // 캐시 주소 — size가 바뀌면 별개 쿼리(별개 캐시 슬롯)가 됩니다.
-    queryKey: ['feed', { size, sort }],
-    // RQ가 호출하는 실제 페치 함수.
+    // 캐시 주소 — 호출부 주입. queryKey가 바뀌면 별개 쿼리(별개 캐시 슬롯)가 됩니다.
+    queryKey,
+    // RQ가 호출하는 실제 페치 함수 — 호출부가 주입한 fetchPage에 위임합니다.
     // signal은 RQ가 자동으로 만들어 주는 AbortSignal입니다.
     // 컴포넌트 언마운트 / queryKey 변경 / queryClient.cancelQueries() 호출 시
     // RQ가 알아서 abort 하므로, v1의 inflightRef + AbortController 수동 관리가 사라집니다.
-    queryFn: ({ pageParam, signal }) =>
-      fetchFeed({
-        size,
-        sort,
-        ...(pageParam ? { cursor: pageParam } : {}),
-        signal,
-      }),
+    queryFn: ({ pageParam, signal }) => fetchPage({ pageParam, signal }),
     // 첫 페이지의 책갈피 — null = "처음부터" (cursor 쿼리 파라미터 없음).
     initialPageParam: null as string | null,
     // 다음 페이지의 책갈피 계산.

--- a/frontend/src/pages/post/PostDetailPage.tsx
+++ b/frontend/src/pages/post/PostDetailPage.tsx
@@ -182,7 +182,9 @@ export default function PostDetailPage() {
     if (!post || !confirm('게시글을 삭제할까요?')) return;
     try {
       await deletePost(post.id);
+      // 전체 피드(['feed'])와 팔로우 피드(['feed-following']) 둘 다 무효화 — 리액션 캐시 패치와 동일하게 두 피드 일관성 유지.
       qc.invalidateQueries({ queryKey: ['feed'] });
+      qc.invalidateQueries({ queryKey: ['feed-following'] });
       navigate('/posts');
     } catch {
       alert('게시글 삭제에 실패했습니다. 다시 시도해주세요.');

--- a/frontend/src/pages/post/PostDetailPage.tsx
+++ b/frontend/src/pages/post/PostDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
 import DOMPurify from 'dompurify';
 import {
   MessageSquare,
@@ -79,7 +79,10 @@ export default function PostDetailPage() {
 
   const { postId } = useParams<{ postId: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const openMessageCompose = useOpenMessageCompose();
+  // 진입 카드가 Link state로 실어 보낸 목적지(쿼리 포함). 없으면 '/posts' 폴백 → 기존 동작 유지.
+  const backTo = (location.state as { from?: string } | null)?.from ?? '/posts';
 
   const [post, setPost] = useState<PostDetail | null>(null);
   const [comments, setComments] = useState<CommentResponse[]>([]);
@@ -301,7 +304,7 @@ export default function PostDetailPage() {
   return (
     <div className="max-w-3xl mx-auto pb-20 md:pb-8">
       {/* 상단 헤더 */}
-      <PageHeader title="게시글" backTo={`/posts`} />
+      <PageHeader title="게시글" backTo={backTo} />
 
       {/* 시안: 흰 카드를 회색 컨테이너 + gap-px로 묶어 카드 사이 1px 회색 띠로 분리 */}
       <div className="bg-gray-200 flex flex-col gap-px">

--- a/frontend/src/pages/post/PostListPage.tsx
+++ b/frontend/src/pages/post/PostListPage.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { isAxiosError } from 'axios';
-import { Plus, Menu } from 'lucide-react';
+import { Plus, Menu, UserPlus } from 'lucide-react';
 import { buttonVariants } from '@/components/shadcn-ui/button';
 import { Skeleton } from '@/components/shadcn-ui/skeleton';
-import { fetchPosts } from '../../api/posts';
+import { fetchPosts, fetchFeed, fetchFollowingFeed } from '../../api/posts';
 import type { TherapyArea, PaginatedPosts, PostReaction } from '../../types/post';
 import { FILTER_CHIPS } from '../../constants/post';
 import WelcomeModal from '@/components/auth/WelcomeModal';
@@ -57,7 +57,8 @@ export default function PostListPage() {
   const therapyArea = (searchParams.get('therapyArea') as TherapyArea) ?? '';
   const currentPage = Number(searchParams.get('page') ?? '1');
 
-  const [activeTab, setActiveTab] = useState<FeedTab>('all');
+  // 탭을 URL에 보존 — 상세 진입 후 뒤로가기 시 마지막 탭 복원(state면 'all'로 리셋됨).
+  const activeTab: FeedTab = searchParams.get('tab') === 'following' ? 'following' : 'all';
   const [data, setData] = useState<PaginatedPosts | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -77,9 +78,10 @@ export default function PostListPage() {
   const qc = useQueryClient();
 
   const infinite = useInfiniteFeed({
-    size: 20,
+    queryKey: ['feed', { size: 20, sort }],
+    fetchPage: ({ pageParam, signal }) =>
+      fetchFeed({ size: 20, sort, ...(pageParam ? { cursor: pageParam } : {}), signal }),
     enabled: isInfiniteMode,
-    sort,
     initialSnapshot: initialSnapshotRef.current
       ? {
           items: initialSnapshotRef.current.items,
@@ -88,6 +90,15 @@ export default function PostListPage() {
         }
       : undefined,
     onError: () => setFeedFailed(true),
+  });
+
+  // 팔로우 탭 무한 스크롤 — 같은 useInfiniteFeed를 ['feed-following'] 키 + fetchFollowingFeed로 재사용.
+  // 전체 피드와 캐시 슬롯이 분리되고, sort/snapshot은 없음(BE sort 미지원·스크롤 복원 미적용).
+  const followingFeed = useInfiniteFeed({
+    queryKey: ['feed-following', { size: 20 }],
+    fetchPage: ({ pageParam, signal }) =>
+      fetchFollowingFeed({ size: 20, ...(pageParam ? { cursor: pageParam } : {}), signal }),
+    enabled: activeTab === 'following',
   });
 
   useEffect(() => {
@@ -141,6 +152,7 @@ export default function PostListPage() {
   }, [therapyArea, currentPage, activeTab, isInfiniteMode]);
 
   const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const followingSentinelRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!isInfiniteMode) return;
@@ -157,6 +169,23 @@ export default function PostListPage() {
     observer.observe(node);
     return () => observer.disconnect();
   }, [isInfiniteMode, infinite.loadMore]);
+
+  // 팔로우 탭 전용 sentinel observer — 전체 피드 옵저버(위)와 독립.
+  useEffect(() => {
+    if (activeTab !== 'following') return;
+    const node = followingSentinelRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          followingFeed.loadMore();
+        }
+      },
+      { rootMargin: '200px' },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [activeTab, followingFeed.loadMore]);
 
   function handleCardClick() {
     if (!isInfiniteMode) return;
@@ -179,6 +208,13 @@ export default function PostListPage() {
     setSearchParams(value ? { therapyArea: value } : {});
   }
 
+  function handleTabChange(tab: FeedTab) {
+    const next = new URLSearchParams(searchParams);
+    if (tab === 'following') next.set('tab', 'following');
+    else next.delete('tab');
+    setSearchParams(next);
+  }
+
   function handlePageChange(page: number) {
     const params: Record<string, string> = { page: String(page) };
     if (therapyArea) params.therapyArea = therapyArea;
@@ -190,7 +226,7 @@ export default function PostListPage() {
 
   function handleReactionUpdated(fresh: PostReaction) {
     // any타입 임시. 나중에 바꿔야함
-    qc.setQueriesData({ queryKey: ['feed'] }, (old: any) => {
+    const patch = (old: any) => {
       if (!old) return old;
       return {
         ...old,
@@ -209,7 +245,10 @@ export default function PostListPage() {
           ),
         })),
       };
-    });
+    };
+    // 전체 피드(['feed'])와 팔로우 피드(['feed-following']) 캐시를 모두 패치.
+    qc.setQueriesData({ queryKey: ['feed'] }, patch);
+    qc.setQueriesData({ queryKey: ['feed-following'] }, patch);
   }
 
   // 빈 상태 CTA — PC는 모달, 모바일은 라우트 이동.
@@ -244,7 +283,7 @@ export default function PostListPage() {
       <div className="bg-white">
         <div className="flex">
           <button
-            onClick={() => setActiveTab('all')}
+            onClick={() => handleTabChange('all')}
             className={`flex-1 py-2 text-xs font-medium text-center transition-colors ${
               activeTab === 'all'
                 ? 'text-neutral-950 border-b-2 border-black'
@@ -254,7 +293,7 @@ export default function PostListPage() {
             전체 피드
           </button>
           <button
-            onClick={() => setActiveTab('following')}
+            onClick={() => handleTabChange('following')}
             className={`flex-1 py-2 text-xs font-medium text-center transition-colors ${
               activeTab === 'following'
                 ? 'text-neutral-950 border-b-2 border-black'
@@ -266,10 +305,12 @@ export default function PostListPage() {
         </div>
       </div>
 
-      {/* 필터 칩 */}
-      <div className="p-4 bg-white border-b border-gray-200">
-        <FilterChips value={therapyArea} onChange={handleFilterClick} />
-      </div>
+      {/* 필터 칩 — 전체 피드에서만 (팔로우 피드는 BE therapyArea 필터 미지원) */}
+      {activeTab === 'all' && (
+        <div className="p-4 bg-white border-b border-gray-200">
+          <FilterChips value={therapyArea} onChange={handleFilterClick} />
+        </div>
+      )}
 
       {/* 정렬 전환 — 무한스크롤 모드(전체 피드 + 필터 없음)에서만 노출 */}
       {isInfiniteMode && (
@@ -392,8 +433,51 @@ export default function PostListPage() {
           )}
         </div>
       ) : (
-        <div className="text-center py-20">
-          <p className="text-gray-400 text-sm">팔로우한 치료사의 글이 여기에 표시됩니다.</p>
+        <div className="bg-white">
+          {followingFeed.isLoading
+            ? Array.from({ length: 4 }).map((_, i) => <PostCardSkeleton key={i} />)
+            : followingFeed.items.map((post) => (
+                <PostCard
+                  key={post.id}
+                  post={post}
+                  onReactionUpdated={handleReactionUpdated}
+                  backTo="/posts?tab=following"
+                />
+              ))}
+
+          {followingFeed.isFetchingMore &&
+            Array.from({ length: 2 }).map((_, i) => <PostCardSkeleton key={`fmore-${i}`} />)}
+
+          {followingFeed.error && (
+            <div className="flex flex-col items-center gap-3 py-8">
+              <p className="text-sm text-destructive">{followingFeed.error}</p>
+              <button
+                onClick={followingFeed.retry}
+                className="px-4 py-2 text-sm font-medium border border-gray-300 rounded-lg hover:bg-gray-50"
+              >
+                재시도
+              </button>
+            </div>
+          )}
+
+          {!followingFeed.isLoading && !followingFeed.error && followingFeed.items.length === 0 && (
+            <div className="text-center py-16">
+              <p className="text-gray-400 mb-4">팔로우한 치료사의 글이 아직 없어요.</p>
+              <button
+                type="button"
+                onClick={() => navigate('/follow')}
+                className={buttonVariants({ size: 'sm' }) + ' gap-1'}
+              >
+                <UserPlus size={15} />치료사 팔로우하러 가기
+              </button>
+            </div>
+          )}
+
+          {!followingFeed.isLoading && !followingFeed.hasNext && followingFeed.items.length > 0 && (
+            <p className="text-center text-sm text-gray-400 py-8">마지막 글이에요</p>
+          )}
+
+          <div ref={followingSentinelRef} aria-hidden className="h-1" />
         </div>
       )}
     </div>


### PR DESCRIPTION
## 개요
홈피드 '팔로우' 탭(접근 B)을 placeholder → 실제 무한스크롤 피드로 배선. 팔로우 1차(PR #25) 후속, FE 단독. backlog **F-15**.

## 변경 (커밋 2개)
### `0d89472` feat(post): 상세 뒤로가기 시 진입 출처(backTo) 보존
- `PostCard`가 진입 출처 URL을 Link `state(from)`로 싣고, `PostDetailPage` 헤더 뒤로가기가 그 state를 backTo로 사용. 미전달 시 `/posts` 폴백 → 프로필/검색/전체피드 등 기존 사용처 동작 그대로.
- 기존 `backTo='/posts'` 하드코딩이라 쿼리 있는 목록(탭/필터)에서 진입 후 인앱 뒤로가기 시 쿼리가 떨어지던 문제 해결.

### `3baa1c9` feat(feed): 홈피드 팔로우 탭 무한스크롤 배선
- `fetchFollowingFeed` 추가 (`/posts/feed/following`, 커서, sort 미지원)
- `useInfiniteFeed`를 `queryKey`+`fetchPage` 주입형으로 일반화 → 전체/팔로우 피드가 동일 무한스크롤 코어 공유, 캐시 슬롯만 분리(`['feed']` / `['feed-following']`)
- 팔로우 탭 placeholder → 무한스크롤 리스트(전용 sentinel observer, 빈 상태 CTA→`/follow`)
- 탭을 `?tab=following` URL에 보존 → 상세 진입 후 뒤로가기 시 탭 복원
- 팔로우 탭에선 필터칩·정렬토글 숨김 (BE therapyArea/sort 미지원)
- 리액션 캐시 패치를 두 피드 키 모두에 적용

## 검증 (dev 서버, 통과)
- 팔로우 탭: 글 로드 / 빈 상태 CTA→`/follow` / 리액션 토글 카운트 반영 / UI 게이팅(필터칩·정렬 숨김)
- 뒤로가기: 팔로우 탭 글 클릭→상세→헤더 ← → **팔로우 탭 유지**
- 전체 피드 Hot Path 회귀 5종(무한스크롤/스크롤·정렬 복원/필터 깜빡임/fallback) 무탈

## 의도된 한계 (후속)
- 팔로우 탭 **스크롤 위치 미복원** — 목록 내용은 RQ 캐시로 복원되나 스크롤은 top. 전체 피드 snapshot store 단일 슬롯 일반화 회피(Hot Path 보호) → backlog 후속.
- 정렬(인기/최신)·therapyArea 필터 없음 — BE following 엔드포인트 미지원.