### PR TITLE
feat: 랜딩페이지 GA4 이벤트 삽입 (landing_clicked + landing_scrolled)

### DIFF
--- a/frontend/src/hooks/useScrollDepth.ts
+++ b/frontend/src/hooks/useScrollDepth.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react';
+import { trackEvent } from '../lib/analytics';
+
+/**
+ * ─────────────────────────────────────────────────────────────────────
+ *  useScrollDepth — 페이지 스크롤 깊이를 GA4 `landing_scrolled` 이벤트로 발송
+ * ─────────────────────────────────────────────────────────────────────
+ *  PM 스펙(2026-06-22 승인): 랜딩 페이지에서 유저가 어디까지 읽고 이탈하는지를
+ *  25/50/75/100% 4개 임계점으로 추적합니다. 각 임계점은 한 번만 발사합니다
+ *  (스크롤을 위아래로 반복해도 같은 depth가 중복 집계되지 않도록).
+ *
+ *  왜 useRef(Set)인가:
+ *  - "이미 발사한 임계점"은 화면에 그려지는 값이 아니라 발송 제어용 플래그입니다.
+ *    state로 두면 매 스크롤마다 setState → 불필요한 리렌더가 폭발합니다.
+ *    ref는 리렌더 없이 값만 들고 있어 이 용도에 정확히 맞습니다.
+ *
+ *  계산식:
+ *  - scrolled = window.scrollY + window.innerHeight  (현재 화면 하단의 문서상 위치)
+ *  - total    = document.documentElement.scrollHeight (전체 문서 높이)
+ *  - percent  = scrolled / total * 100
+ *  - 즉 "화면 하단이 문서의 몇 %까지 내려왔는가" = 읽은 깊이.
+ *    문서 끝까지 스크롤하면 scrolled === total → 100%.
+ *
+ *  passive 리스너:
+ *  - { passive: true }는 "이 핸들러는 preventDefault를 호출하지 않는다"는 약속.
+ *    브라우저가 스크롤을 기다리지 않고 즉시 처리해 스크롤 성능(jank)을 지킵니다.
+ *
+ *  throttle 불필요:
+ *  - scroll은 고빈도 이벤트지만, 핸들러는 Set 조회 + 나눗셈 한 번뿐이라 가볍습니다.
+ *    한 임계점은 Set 가드로 1회만 trackEvent를 호출하므로 발송 폭주도 없습니다.
+ *
+ *  초기 1회 호출:
+ *  - 뷰포트보다 짧은 문서(또는 모바일에서 이미 하단까지 보이는 경우)는
+ *    스크롤이 발생하지 않아 이벤트가 영영 안 뜰 수 있습니다.
+ *    마운트 직후 handleScroll()을 한 번 불러 그 시점의 도달 깊이를 즉시 캡처합니다.
+ *
+ *  사용:
+ *    function LandingPage() {
+ *      useScrollDepth();
+ *      // ...
+ *    }
+ * ─────────────────────────────────────────────────────────────────────
+ */
+const THRESHOLDS = [25, 50, 75, 100] as const;
+
+export function useScrollDepth(): void {
+  // 이미 발사한 임계점 집합. 마운트~언마운트 동안 유지되며 리렌더를 일으키지 않음.
+  const firedRef = useRef<Set<number>>(new Set());
+
+  useEffect(() => {
+    function handleScroll() {
+      const scrolled = window.scrollY + window.innerHeight;
+      const total = document.documentElement.scrollHeight;
+      // 0으로 나누기 방지(문서 높이가 0인 비정상 타이밍).
+      if (total <= 0) return;
+      const percent = (scrolled / total) * 100;
+
+      for (const t of THRESHOLDS) {
+        if (percent >= t && !firedRef.current.has(t)) {
+          firedRef.current.add(t); // 1회성 가드 — 같은 depth 재발송 차단.
+          trackEvent('landing_scrolled', { depth: t });
+        }
+      }
+    }
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll(); // 초기 도달 깊이 즉시 캡처(짧은 문서/모바일 대비).
+
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+}

--- a/frontend/src/lib/analytics.ts
+++ b/frontend/src/lib/analytics.ts
@@ -86,3 +86,35 @@ export function trackReaction(
  * 어휘를 쓰도록 한 곳에서 정의하기 위함입니다 (오타 방지).
  */
 export type ScreenName = 'feed' | 'post_write' | 'my_page';
+
+/**
+ * `landing_clicked` 이벤트의 type 파라미터로 허용되는 7종.
+ *
+ * PM 스펙(2026-06-22 승인): 랜딩 페이지의 주요 클릭 지점을 단일 이벤트 +
+ * type 파라미터로 통합합니다 (reaction과 동일한 카운트 인플레 방지 설계).
+ *
+ * type은 "랜딩 슬롯 위치"를 식별합니다 — 라벨/목적지가 로그인 여부에 따라
+ * 갈리는 슬롯(nav_community, last_cta)도 같은 type을 쓰고, 부가 파라미터
+ * `loggedIn`으로 비로그인/로그인 유저의 클릭을 분리해 유입 분석에 활용합니다.
+ */
+export type LandingClickType =
+  | 'nav_contact'
+  | 'nav_community'
+  | 'hero_cta'
+  | 'last_cta'
+  | 'footer_terms'
+  | 'footer_privacy'
+  | 'footer_instagram';
+
+/**
+ * `landing_clicked` 단일 이벤트 헬퍼.
+ *
+ * @param type   클릭 슬롯 (위 7종 중 하나)
+ * @param params 부가 파라미터. 조건부 슬롯은 `{ loggedIn: !!user }`를 함께 보냅니다.
+ */
+export function trackLandingClick(
+  type: LandingClickType,
+  params?: Record<string, unknown>,
+): void {
+  trackEvent('landing_clicked', { type, ...(params ?? {}) });
+}

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom';
 import { ArrowLeft, Upload, PencilLine, LockOpen, MessageCircle, Heart } from 'lucide-react';
 import { useAuthStore } from '../../stores/useAuthStore';
 import { useScrollReveal } from '../../hooks/useScrollReveal';
+import { useScrollDepth } from '../../hooks/useScrollDepth';
+import { trackLandingClick } from '../../lib/analytics';
 
 /**
  * Mellti 랜딩 페이지 (비로그인 진입 화면).
@@ -18,6 +20,7 @@ export default function LandingPage() {
   const user = useAuthStore((s) => s.user);
   const rootRef = useRef<HTMLDivElement>(null);
   useScrollReveal(rootRef);
+  useScrollDepth(); // 25/50/75/100% 도달 시 landing_scrolled 발사
 
   return (
     <div ref={rootRef} className="min-h-screen bg-white font-sans text-neutral-900">
@@ -36,6 +39,7 @@ export default function LandingPage() {
               href="https://pf.kakao.com/_qxfBAX"
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => trackLandingClick('nav_contact')}
               className="text-sm font-medium text-neutral-500 transition-colors hover:text-neutral-900"
             >
               협업문의
@@ -43,6 +47,7 @@ export default function LandingPage() {
             {user ? (
               <Link
                 to="/posts"
+                onClick={() => trackLandingClick('nav_community', { loggedIn: true })}
                 className="inline-flex items-center rounded-full bg-neutral-900 px-6 py-2.5 text-sm font-semibold text-white transition-all hover:bg-neutral-700"
               >
                 커뮤니티
@@ -50,6 +55,7 @@ export default function LandingPage() {
             ) : (
               <Link
                 to="/login"
+                onClick={() => trackLandingClick('nav_community', { loggedIn: false })}
                 className="inline-flex items-center rounded-full bg-neutral-900 px-6 py-2.5 text-sm font-semibold text-white transition-all hover:bg-neutral-700"
               >
                 로그인
@@ -105,6 +111,7 @@ export default function LandingPage() {
               <Link
                 data-animate
                 to={user ? '/posts' : '/login'}
+                onClick={() => trackLandingClick('hero_cta', { loggedIn: !!user })}
                 className="inline-flex items-center gap-2 rounded-full bg-neutral-900 px-9 py-[15px] text-base font-semibold text-white shadow-[0_2px_12px_rgba(0,0,0,0.15)] transition-all hover:-translate-y-0.5 hover:bg-neutral-800 hover:shadow-[0_6px_24px_rgba(0,0,0,0.2)]"
               >
                 지금 시작하기
@@ -596,6 +603,7 @@ export default function LandingPage() {
             {/* 로그인 상태면 홈피드(/posts), 아니면 로그인 화면으로 — 텍스트도 함께 분기 */}
             <Link
               to={user ? '/posts' : '/login'}
+              onClick={() => trackLandingClick('last_cta', { loggedIn: !!user })}
               className="inline-flex items-center gap-2 rounded-full bg-white px-9 py-[15px] text-base font-semibold text-neutral-900 shadow-[0_2px_16px_rgba(255,255,255,0.1)] transition-all hover:-translate-y-0.5 hover:bg-neutral-100 hover:shadow-[0_6px_30px_rgba(255,255,255,0.15)]"
             >
               {user ? '커뮤니티 둘러보기' : '로그인하러 가기'}
@@ -626,12 +634,14 @@ export default function LandingPage() {
             <div className="flex items-center gap-5">
               <Link
                 to="/terms"
+                onClick={() => trackLandingClick('footer_terms')}
                 className="text-[0.85rem] text-neutral-400 transition-colors hover:text-neutral-900"
               >
                 이용약관
               </Link>
               <Link
                 to="/privacy"
+                onClick={() => trackLandingClick('footer_privacy')}
                 className="text-[0.85rem] text-neutral-400 transition-colors hover:text-neutral-900"
               >
                 개인정보 처리방침
@@ -642,6 +652,7 @@ export default function LandingPage() {
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="아이로 인스타그램"
+                onClick={() => trackLandingClick('footer_instagram')}
                 className="text-neutral-400 transition-colors hover:text-neutral-900"
               >
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">


### PR DESCRIPTION
## 요약
PM 승인 스펙(2026-06-22)대로 랜딩페이지에 GA4 이벤트 2종을 삽입합니다. 코드 추가만 있고 기존 동작·UI 변경 없음(클릭 시 navigate 그대로, 이벤트만 추가 발사).

## 변경
- **`lib/analytics.ts`** — `LandingClickType`(7종) + `trackLandingClick` 헬퍼. `reaction`/`trackReaction`과 동일한 "단일 이벤트 + type 파라미터" 컨벤션.
- **`hooks/useScrollDepth.ts`** (신규) — 25/50/75/100% 도달 시 `landing_scrolled` 1회씩 발사. `useScreenExit` 패턴 차용.
- **`pages/landing/LandingPage.tsx`** — 훅 호출 1줄 + 클릭 7개 `onClick` 배선.

## 이벤트 매핑
| type | 요소 |
|---|---|
| `nav_contact` | 협업문의(카카오 채널) |
| `nav_community` | 우상단 버튼(커뮤니티/로그인) |
| `hero_cta` | 지금 시작하기 |
| `last_cta` | 하단 CTA(커뮤니티 둘러보기/로그인하러 가기) |
| `footer_terms` / `footer_privacy` / `footer_instagram` | 푸터 3종 |

`landing_scrolled` → `depth: 25|50|75|100`

## 결정 사항 (리뷰 시 확인)
1. **`loggedIn` 파라미터 범위** — 승인 표엔 없던 추가지만, 목적지가 auth로 갈리는 CTA에 `{ loggedIn: !!user }`를 동봉했습니다. 질문에서 정한 nav_community·last_cta **2개 + hero_cta까지 3개**에 적용(hero_cta도 `/posts`↔`/login`로 갈려 동일 근거). hero_cta는 빼고 2개만 둘지 의견 주세요.
2. **type = 슬롯 위치** — 라벨이 갈리는 버튼도 같은 type을 쓰고 loggedIn으로만 구분(비로그인 이탈 직전 클릭이 유입 분석에 중요).

## 새 로직 자기점검 — `useScrollDepth` (리뷰 때 이해 잡기용)
AI 작성 새 로직이라 인지부채 방지용 질문 3개:
1. `firedRef`를 `useState`가 아니라 `useRef(Set)`로 둔 이유? (힌트: 발사 여부는 화면에 안 그려짐 → 리렌더 불필요)
2. 리스너에 `{ passive: true }`를 붙인 이유? (스크롤 성능 — preventDefault 안 함을 브라우저에 약속)
3. `useEffect`에서 마운트 직후 `handleScroll()`를 한 번 직접 부르는 이유? (뷰포트보다 짧은 문서/모바일은 스크롤이 안 일어나 100%를 놓침)

## QA 가이드
- `npm run dev` → `/` 진입 → DevTools 콘솔에 `[GA4] landing_clicked {type, ...}` / `[GA4] landing_scrolled {depth}` 로그 확인(DEV는 gtag 없이도 콘솔만 찍힘).
- prod 실측은 GA4 DebugView에서 7종 type + depth 4종 발생 확인.

## 검증
- `tsc -b` ✅ / `eslint` (touched files) ✅

base: `develop`
