### PR TITLE
feat: 구인공고 Phase1 — 읽기 전용 구인 탭 + 상세 (MSW 더미)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import TermsPage from './pages/TermsPage';
 import PostListPage from './pages/post/PostListPage';
 import PostDetailPage from './pages/post/PostDetailPage';
 import PostCreatePage from './pages/post/PostCreatePage';
+import JobPostDetailPage from './pages/jobpost/JobPostDetailPage';
 import PostEditPage from './pages/post/PostEditPage';
 import CommentWritePage from './pages/post/CommentWritePage';
 import CommentDetailPage from './pages/post/CommentDetailPage';
@@ -81,6 +82,7 @@ function App() {
             <Route path="/posts/:postId/comments" element={<CommentWritePage />} />
             <Route path="/posts/:postId/comments/:commentId" element={<CommentDetailPage />} />
             <Route path="/posts/new" element={<PostCreatePage />} />
+            <Route path="/job-posts/:jobPostId" element={<JobPostDetailPage />} />
             <Route path="/posts/:postId/edit" element={<PostEditPage />} />
             <Route path="/search" element={<SearchPage />} />
             <Route path="/notifications" element={<NotificationPage />} />

--- a/frontend/src/api/jobPosts.ts
+++ b/frontend/src/api/jobPosts.ts
@@ -1,0 +1,25 @@
+import axiosInstance from './axiosInstance';
+import type {
+  CursorPagedJobPosts,
+  JobPostDetail,
+  JobPostListParams,
+} from '../types/jobPost';
+
+// 구인공고 목록 — cursor 페이지네이션 + 필터(status/therapyArea/region/employmentType).
+// 응답 shape은 피드와 동일하게 { success, data:{ items, nextCursor, hasNext, size } }.
+// axiosInstance 인터셉터가 success+data를 이미 벗기지만, fetchFeed와 동일하게 방어적으로 한 번 더 unwrap.
+export async function fetchJobPosts(
+  params: JobPostListParams & { signal?: AbortSignal },
+): Promise<CursorPagedJobPosts> {
+  const { signal, ...query } = params;
+  const res = await axiosInstance.get('/job-posts', { params: query, signal });
+  return res.data?.data ?? res.data;
+}
+
+export async function fetchJobPostDetail(
+  id: number,
+  signal?: AbortSignal,
+): Promise<JobPostDetail> {
+  const res = await axiosInstance.get(`/job-posts/${id}`, { signal });
+  return res.data?.data ?? res.data;
+}

--- a/frontend/src/components/jobpost/JobPostCard.tsx
+++ b/frontend/src/components/jobpost/JobPostCard.tsx
@@ -1,0 +1,56 @@
+import { Link } from 'react-router-dom';
+import { Building2 } from 'lucide-react';
+import type { JobPostSummary } from '../../types/jobPost';
+import JobStatusBadge from './JobStatusBadge';
+import { ddayLabel, isClosed } from '../../utils/jobPost';
+
+interface JobPostCardProps {
+  job: JobPostSummary;
+  // 상세 진입 후 뒤로가기 목적지(탭 보존). 미전달 시 상세는 '/posts?tab=jobs' 폴백.
+  backTo?: string;
+}
+
+export default function JobPostCard({ job, backTo }: JobPostCardProps) {
+  const closed = isClosed(job.status, job.dday);
+  return (
+    <Link
+      to={`/job-posts/${job.id}`}
+      state={backTo ? { from: backTo } : undefined}
+      className="block"
+    >
+      <div className="px-6 py-5 border-b border-gray-200 hover:bg-gray-50 transition-colors">
+        {/* 1행: 상태 배지 + D-day */}
+        <div className="flex items-center justify-between mb-2">
+          <JobStatusBadge status={job.status} dday={job.dday} />
+          {!closed && (
+            <span className="text-xs font-semibold text-emerald-600">
+              {ddayLabel(job.status, job.dday)}
+            </span>
+          )}
+        </div>
+
+        {/* 2행: 제목 */}
+        <h3 className="text-base font-bold text-neutral-950 mb-1 line-clamp-1">{job.title}</h3>
+
+        {/* 3행: 기관명 */}
+        <div className="flex items-center gap-1 text-sm text-gray-500 mb-2.5">
+          <Building2 size={14} className="shrink-0" />
+          <span className="line-clamp-1">{job.organizationName}</span>
+        </div>
+
+        {/* 4행: 라벨 칩 3종 */}
+        <div className="flex flex-wrap gap-1.5">
+          <Tag>{job.therapyAreaLabel}</Tag>
+          <Tag>{job.regionLabel}</Tag>
+          <Tag>{job.employmentTypeLabel}</Tag>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+function Tag({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="bg-gray-100 text-gray-600 text-xs rounded-full px-2 py-0.5">{children}</span>
+  );
+}

--- a/frontend/src/components/jobpost/JobPostFeed.tsx
+++ b/frontend/src/components/jobpost/JobPostFeed.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useRef, useState } from 'react';
+import FilterChips from '../common/FilterChips';
+import JobPostCard from './JobPostCard';
+import { useInfiniteJobPosts } from '../../hooks/useInfiniteJobPosts';
+import { REGION_FILTER_OPTIONS, EMPLOYMENT_FILTER_OPTIONS } from '../../constants/jobPost';
+import type { TherapyArea } from '../../types/post';
+import type { EmploymentType, JobRegion } from '../../types/jobPost';
+
+// 홈피드 "구인" 탭 본문. PostListPage의 PostSummary 머신과 격리 — 자체 데이터/필터/카드 소유.
+// 필터는 로컬 state(Phase 1). 뒤로가기 시 필터 복원은 미지원(범위 밖).
+export default function JobPostFeed() {
+  const [therapyArea, setTherapyArea] = useState<TherapyArea | ''>('');
+  const [region, setRegion] = useState<JobRegion | ''>('');
+  const [employmentType, setEmploymentType] = useState<EmploymentType | ''>('');
+  const [openOnly, setOpenOnly] = useState(true);
+
+  const feed = useInfiniteJobPosts({
+    status: openOnly ? 'OPEN' : undefined,
+    therapyArea: therapyArea || undefined,
+    region: region || undefined,
+    employmentType: employmentType || undefined,
+  });
+
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const node = sentinelRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) feed.loadMore();
+      },
+      { rootMargin: '200px' },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [feed.loadMore]);
+
+  const selectClass =
+    'flex-1 min-w-0 rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-xs text-gray-700';
+
+  return (
+    <div className="bg-white">
+      {/* 필터 */}
+      <div className="p-4 border-b border-gray-200 space-y-3">
+        <FilterChips value={therapyArea} onChange={setTherapyArea} />
+        <div className="flex items-center gap-2">
+          <select
+            value={region}
+            onChange={(e) => setRegion(e.target.value as JobRegion | '')}
+            className={selectClass}
+          >
+            {REGION_FILTER_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+          <select
+            value={employmentType}
+            onChange={(e) => setEmploymentType(e.target.value as EmploymentType | '')}
+            className={selectClass}
+          >
+            {EMPLOYMENT_FILTER_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={() => setOpenOnly((v) => !v)}
+            className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+              openOnly
+                ? 'bg-gray-900 text-white border-gray-900'
+                : 'text-gray-500 border-gray-300 hover:border-gray-400'
+            }`}
+          >
+            모집중만
+          </button>
+        </div>
+      </div>
+
+      {/* 목록 */}
+      {feed.isLoading
+        ? Array.from({ length: 4 }).map((_, i) => <JobPostCardSkeleton key={i} />)
+        : feed.items.map((job) => (
+            <JobPostCard key={job.id} job={job} backTo="/posts?tab=jobs" />
+          ))}
+
+      {feed.isFetchingMore &&
+        Array.from({ length: 2 }).map((_, i) => <JobPostCardSkeleton key={`more-${i}`} />)}
+
+      {feed.error && (
+        <div className="flex flex-col items-center gap-3 py-8">
+          <p className="text-sm text-destructive">{feed.error}</p>
+          <button
+            onClick={feed.retry}
+            className="px-4 py-2 text-sm font-medium border border-gray-300 rounded-lg hover:bg-gray-50"
+          >
+            재시도
+          </button>
+        </div>
+      )}
+
+      {!feed.isLoading && !feed.error && feed.items.length === 0 && (
+        <div className="text-center py-16">
+          <p className="text-gray-400">조건에 맞는 구인공고가 없어요.</p>
+        </div>
+      )}
+
+      {!feed.isLoading && !feed.hasNext && feed.items.length > 0 && (
+        <p className="text-center text-sm text-gray-400 py-8">마지막 공고예요</p>
+      )}
+
+      <div ref={sentinelRef} aria-hidden className="h-1" />
+    </div>
+  );
+}
+
+function JobPostCardSkeleton() {
+  return (
+    <div className="px-6 py-5 border-b border-gray-200 animate-pulse">
+      <div className="h-4 w-16 bg-gray-100 rounded-full mb-2" />
+      <div className="h-5 w-2/3 bg-gray-100 rounded mb-2" />
+      <div className="h-4 w-1/2 bg-gray-100 rounded mb-3" />
+      <div className="flex gap-1.5">
+        <div className="h-5 w-14 bg-gray-100 rounded-full" />
+        <div className="h-5 w-14 bg-gray-100 rounded-full" />
+        <div className="h-5 w-14 bg-gray-100 rounded-full" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/jobpost/JobStatusBadge.tsx
+++ b/frontend/src/components/jobpost/JobStatusBadge.tsx
@@ -1,0 +1,21 @@
+import type { JobPostStatus } from '../../types/jobPost';
+import { isClosed } from '../../utils/jobPost';
+
+export default function JobStatusBadge({
+  status,
+  dday,
+}: {
+  status: JobPostStatus;
+  dday: number | null;
+}) {
+  const closed = isClosed(status, dday);
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${
+        closed ? 'bg-gray-100 text-gray-400' : 'bg-emerald-50 text-emerald-600'
+      }`}
+    >
+      {closed ? '마감' : '모집중'}
+    </span>
+  );
+}

--- a/frontend/src/constants/jobPost.ts
+++ b/frontend/src/constants/jobPost.ts
@@ -1,0 +1,48 @@
+import type { EmploymentType, JobRegion } from '../types/jobPost';
+
+export const REGION_LABELS: Record<JobRegion, string> = {
+  SEOUL: '서울',
+  BUSAN: '부산',
+  DAEGU: '대구',
+  INCHEON: '인천',
+  GWANGJU: '광주',
+  DAEJEON: '대전',
+  ULSAN: '울산',
+  SEJONG: '세종',
+  GYEONGGI: '경기',
+  GANGWON: '강원',
+  CHUNGBUK: '충북',
+  CHUNGNAM: '충남',
+  JEONBUK: '전북',
+  JEONNAM: '전남',
+  GYEONGBUK: '경북',
+  GYEONGNAM: '경남',
+  JEJU: '제주',
+  REMOTE: '재택',
+  NATIONWIDE: '전국',
+};
+
+export const EMPLOYMENT_TYPE_LABELS: Record<EmploymentType, string> = {
+  FULL_TIME: '정규직',
+  CONTRACT: '계약직',
+  PART_TIME: '파트타임',
+  FREELANCE: '프리랜서',
+  INTERN: '인턴',
+};
+
+// 필터 드롭다운 옵션 ('' = 전체)
+export const REGION_FILTER_OPTIONS: { value: JobRegion | ''; label: string }[] = [
+  { value: '', label: '지역 전체' },
+  ...(Object.keys(REGION_LABELS) as JobRegion[]).map((v) => ({
+    value: v,
+    label: REGION_LABELS[v],
+  })),
+];
+
+export const EMPLOYMENT_FILTER_OPTIONS: { value: EmploymentType | ''; label: string }[] = [
+  { value: '', label: '고용형태 전체' },
+  ...(Object.keys(EMPLOYMENT_TYPE_LABELS) as EmploymentType[]).map((v) => ({
+    value: v,
+    label: EMPLOYMENT_TYPE_LABELS[v],
+  })),
+];

--- a/frontend/src/hooks/useInfiniteJobPosts.ts
+++ b/frontend/src/hooks/useInfiniteJobPosts.ts
@@ -1,0 +1,49 @@
+import { useCallback, useMemo } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { fetchJobPosts } from '../api/jobPosts';
+import type { JobPostListParams, JobPostSummary } from '../types/jobPost';
+
+// 구인공고 전용 무한 스크롤 훅.
+// 전체/팔로우 피드의 useInfiniteFeed는 PostSummary/CursorPagedPosts에 강결합돼 있어 일반화 대신
+// 동일 패턴(useInfiniteQuery + cursor)을 별도로 둔다. 스냅샷 복원은 Phase 1 범위 밖(미지원).
+type Filters = Pick<JobPostListParams, 'status' | 'therapyArea' | 'region' | 'employmentType'>;
+
+interface UseInfiniteJobPostsResult {
+  items: JobPostSummary[];
+  isLoading: boolean;
+  isFetchingMore: boolean;
+  error: string | null;
+  hasNext: boolean;
+  loadMore: () => void;
+  retry: () => void;
+}
+
+export function useInfiniteJobPosts(filters: Filters, size = 10): UseInfiniteJobPostsResult {
+  const query = useInfiniteQuery({
+    queryKey: ['job-posts', { ...filters, size }],
+    queryFn: ({ pageParam, signal }) =>
+      fetchJobPosts({ ...filters, cursor: pageParam ?? undefined, size, signal }),
+    initialPageParam: null as string | null,
+    getNextPageParam: (last) => (last.hasNext ? last.nextCursor : undefined),
+    retry: false,
+    staleTime: 30_000,
+  });
+
+  const items = useMemo(() => query.data?.pages.flatMap((p) => p.items) ?? [], [query.data]);
+  const hasNext = query.hasNextPage ?? false;
+
+  const loadMore = useCallback(() => {
+    if (query.isLoading || query.isFetchingNextPage || !hasNext || query.isError) return;
+    query.fetchNextPage();
+  }, [query.isLoading, query.isFetchingNextPage, hasNext, query.isError, query.fetchNextPage]);
+
+  return {
+    items,
+    isLoading: query.isLoading,
+    isFetchingMore: query.isFetchingNextPage,
+    error: query.isError ? '구인공고를 불러오는 데 실패했습니다.' : null,
+    hasNext,
+    loadMore,
+    retry: () => query.refetch(),
+  };
+}

--- a/frontend/src/mocks/data/jobPosts.ts
+++ b/frontend/src/mocks/data/jobPosts.ts
@@ -1,0 +1,209 @@
+import type { JobPostDetail } from '../../types/jobPost';
+import { REGION_LABELS, EMPLOYMENT_TYPE_LABELS } from '../../constants/jobPost';
+import { THERAPY_AREA_LABELS } from '../../constants/post';
+
+// 더미 구인공고 — staging 실데이터 0건이라 개발/표시 검증용.
+// AI 큐레이션 형태(sourceUrl 필수, 외부 원문) 모사. id 내림차순(최신순) 유지 → cursor 페이지네이션용.
+type Seed = Pick<
+  JobPostDetail,
+  | 'id'
+  | 'title'
+  | 'organizationName'
+  | 'therapyArea'
+  | 'region'
+  | 'employmentType'
+  | 'status'
+  | 'dday'
+  | 'deadlineDate'
+  | 'content'
+  | 'sourceUrl'
+> &
+  Partial<Pick<JobPostDetail, 'qualification' | 'preferred' | 'salaryText'>>;
+
+const seeds: Seed[] = [
+  {
+    id: 12,
+    title: '언어재활사 정규직 모집',
+    organizationName: '햇살아동발달센터',
+    therapyArea: 'SPEECH',
+    region: 'SEOUL',
+    employmentType: 'FULL_TIME',
+    status: 'OPEN',
+    dday: 12,
+    deadlineDate: '2026-07-06',
+    salaryText: '면접 후 협의 (경력 우대)',
+    content:
+      '서울 강남권 아동발달센터에서 언어재활사를 모집합니다.\n\n- 근무: 주 5일 (월~금)\n- 대상: 만 3~12세 발달지연 아동\n- 평가 및 개별 치료 세션 진행',
+    qualification: '언어재활사 2급 이상 자격 소지자',
+    preferred: '아동 언어치료 경력 1년 이상, 보호자 상담 경험',
+    sourceUrl: 'https://example.com/jobs/12',
+  },
+  {
+    id: 11,
+    title: '감각통합 작업치료사 (계약직)',
+    organizationName: '키움소아청소년발달의원',
+    therapyArea: 'SENSORY_INTEGRATION',
+    region: 'GYEONGGI',
+    employmentType: 'CONTRACT',
+    status: 'OPEN',
+    dday: 5,
+    deadlineDate: '2026-06-29',
+    salaryText: '월 320만원~',
+    content:
+      '경기 분당 소재 의원에서 감각통합 치료를 담당할 작업치료사를 채용합니다.\n\n감각통합 장비 완비, 신규 선생님 교육 지원.',
+    qualification: '작업치료사 면허 소지자',
+    sourceUrl: 'https://example.com/jobs/11',
+  },
+  {
+    id: 10,
+    title: '놀이치료 선생님 파트타임',
+    organizationName: '마음숲심리상담센터',
+    therapyArea: 'PLAY',
+    region: 'INCHEON',
+    employmentType: 'PART_TIME',
+    status: 'OPEN',
+    dday: 0,
+    deadlineDate: '2026-06-24',
+    content:
+      '오후 시간대(14시~19시) 놀이치료 세션을 진행하실 선생님을 찾습니다.\n주 3회 근무 가능자 우대.',
+    preferred: '놀이치료 수련 과정 이수자',
+    sourceUrl: 'https://example.com/jobs/10',
+  },
+  {
+    id: 9,
+    title: '인지학습 치료사 모집 (프리랜서)',
+    organizationName: '브레인업학습클리닉',
+    therapyArea: 'COGNITIVE',
+    region: 'BUSAN',
+    employmentType: 'FREELANCE',
+    status: 'OPEN',
+    dday: 20,
+    deadlineDate: '2026-07-14',
+    salaryText: '세션당 4~6만원',
+    content: '부산 해운대 학습클리닉에서 인지·학습 치료 프리랜서 선생님을 모십니다.',
+    sourceUrl: 'https://example.com/jobs/9',
+  },
+  {
+    id: 8,
+    title: '미술치료사 정규직 (신규 오픈)',
+    organizationName: '컬러풀아동심리연구소',
+    therapyArea: 'ART',
+    region: 'DAEGU',
+    employmentType: 'FULL_TIME',
+    status: 'OPEN',
+    dday: 8,
+    deadlineDate: '2026-07-02',
+    salaryText: '연 3,200만원~',
+    content: '대구 신규 오픈 센터에서 미술치료사를 모십니다. 초기 멤버 합류 기회.',
+    qualification: '미술치료사 자격 소지자',
+    preferred: '집단 미술치료 경험',
+    sourceUrl: 'https://example.com/jobs/8',
+  },
+  {
+    id: 7,
+    title: '음악치료사 채용',
+    organizationName: '하모니발달센터',
+    therapyArea: 'MUSIC',
+    region: 'DAEJEON',
+    employmentType: 'CONTRACT',
+    status: 'OPEN',
+    dday: 15,
+    deadlineDate: '2026-07-09',
+    content: '대전 음악치료사 채용 공고입니다. 악기 및 음향 장비 지원.',
+    sourceUrl: 'https://example.com/jobs/7',
+  },
+  {
+    id: 6,
+    title: '행동치료(ABA) 치료사 모집',
+    organizationName: 'ABA행동발달연구소',
+    therapyArea: 'BEHAVIOR',
+    region: 'SEOUL',
+    employmentType: 'FULL_TIME',
+    status: 'OPEN',
+    dday: 3,
+    deadlineDate: '2026-06-27',
+    salaryText: '면접 후 협의',
+    content: '자폐스펙트럼 아동 대상 ABA 프로그램을 운영할 치료사를 모집합니다.',
+    qualification: '관련 학과 졸업 또는 ABA 수련 경험자',
+    sourceUrl: 'https://example.com/jobs/6',
+  },
+  {
+    id: 5,
+    title: '물리치료사 (소아 재활)',
+    organizationName: '튼튼재활의학과의원',
+    therapyArea: 'PHYSICAL',
+    region: 'GWANGJU',
+    employmentType: 'FULL_TIME',
+    status: 'OPEN',
+    dday: 30,
+    deadlineDate: '2026-07-24',
+    salaryText: '월 350만원~',
+    content: '광주 소재 재활의학과에서 소아 재활 물리치료사를 채용합니다.',
+    qualification: '물리치료사 면허 소지자',
+    sourceUrl: 'https://example.com/jobs/5',
+  },
+  {
+    id: 4,
+    title: '언어치료사 (재택 평가 지원)',
+    organizationName: '온라인발달케어',
+    therapyArea: 'SPEECH',
+    region: 'REMOTE',
+    employmentType: 'FREELANCE',
+    status: 'OPEN',
+    dday: 18,
+    deadlineDate: '2026-07-12',
+    content: '비대면 발달 평가 리포트 작성을 지원할 언어치료사를 모십니다. 재택 근무.',
+    preferred: '평가 보고서 작성 경험',
+    sourceUrl: 'https://example.com/jobs/4',
+  },
+  {
+    id: 3,
+    title: '작업치료사 인턴 (전국 채용)',
+    organizationName: '한국아동발달네트워크',
+    therapyArea: 'OCCUPATIONAL',
+    region: 'NATIONWIDE',
+    employmentType: 'INTERN',
+    status: 'OPEN',
+    dday: 25,
+    deadlineDate: '2026-07-19',
+    content: '전국 지점에서 근무할 작업치료 인턴을 모집합니다. 정규직 전환 기회.',
+    sourceUrl: 'https://example.com/jobs/3',
+  },
+  {
+    id: 2,
+    title: '놀이치료사 모집 (마감)',
+    organizationName: '푸른나무아동센터',
+    therapyArea: 'PLAY',
+    region: 'GYEONGNAM',
+    employmentType: 'FULL_TIME',
+    status: 'CLOSED',
+    dday: -2,
+    deadlineDate: '2026-06-22',
+    content: '경남 창원 놀이치료사 모집 공고였습니다. (마감)',
+    sourceUrl: 'https://example.com/jobs/2',
+  },
+  {
+    id: 1,
+    title: '감각통합 치료사 (마감)',
+    organizationName: '연세아동발달의원',
+    therapyArea: 'SENSORY_INTEGRATION',
+    region: 'JEJU',
+    employmentType: 'CONTRACT',
+    status: 'CLOSED',
+    dday: -5,
+    deadlineDate: '2026-06-19',
+    content: '제주 감각통합 치료사 모집 공고였습니다. (마감)',
+    sourceUrl: 'https://example.com/jobs/1',
+  },
+];
+
+export const mockJobPosts: JobPostDetail[] = seeds.map((s) => ({
+  ...s,
+  therapyAreaLabel: THERAPY_AREA_LABELS[s.therapyArea] ?? s.therapyArea,
+  regionLabel: REGION_LABELS[s.region],
+  employmentTypeLabel: EMPLOYMENT_TYPE_LABELS[s.employmentType],
+  qualification: s.qualification ?? null,
+  preferred: s.preferred ?? null,
+  salaryText: s.salaryText ?? null,
+  authorNickname: 'Mellti AI',
+}));

--- a/frontend/src/mocks/handlers/index.ts
+++ b/frontend/src/mocks/handlers/index.ts
@@ -9,6 +9,7 @@ import { reactionsHandlers } from './reactions.handlers';
 import { profileHandlers } from './profile.handlers';
 import { scrapHandlers } from './scrap.handlers';
 import { notificationsHandlers } from './notifications.handlers';
+import { jobPostsHandlers } from './jobPosts.handlers';
 
 export const handlers = [
   ...authHandlers,
@@ -21,4 +22,5 @@ export const handlers = [
   ...profileHandlers,
   ...scrapHandlers,
   ...notificationsHandlers,
+  ...jobPostsHandlers,
 ];

--- a/frontend/src/mocks/handlers/jobPosts.handlers.ts
+++ b/frontend/src/mocks/handlers/jobPosts.handlers.ts
@@ -1,0 +1,85 @@
+// 구인공고 핸들러 — 목록(cursor + 필터 4종), 상세. Phase 1 읽기 전용.
+import { http, HttpResponse } from 'msw';
+import { mockJobPosts } from '../data/jobPosts';
+
+const API = import.meta.env.VITE_API_BASE_URL;
+
+function encodeCursor(lastId: number): string {
+  return btoa(JSON.stringify({ lastId }));
+}
+
+function decodeCursor(cursor: string): number | null {
+  try {
+    const parsed = JSON.parse(atob(cursor));
+    return typeof parsed.lastId === 'number' ? parsed.lastId : null;
+  } catch {
+    return null;
+  }
+}
+
+export const jobPostsHandlers = [
+  http.get(`${API}/job-posts`, ({ request }) => {
+    const url = new URL(request.url);
+    const status = url.searchParams.get('status');
+    const therapyArea = url.searchParams.get('therapyArea');
+    const region = url.searchParams.get('region');
+    const employmentType = url.searchParams.get('employmentType');
+    const rawSize = Number(url.searchParams.get('size') ?? '10');
+    const size = Math.min(50, Math.max(1, isNaN(rawSize) ? 10 : rawSize));
+    const cursor = url.searchParams.get('cursor');
+
+    // mockJobPosts는 id 내림차순(최신순) 정렬 상태.
+    let filtered = mockJobPosts;
+    if (status) filtered = filtered.filter((j) => j.status === status);
+    if (therapyArea) filtered = filtered.filter((j) => j.therapyArea === therapyArea);
+    if (region) filtered = filtered.filter((j) => j.region === region);
+    if (employmentType) filtered = filtered.filter((j) => j.employmentType === employmentType);
+
+    let startIdx = 0;
+    if (cursor) {
+      const lastId = decodeCursor(cursor);
+      if (lastId === null) {
+        return HttpResponse.json(
+          { success: false, code: 'INVALID_INPUT', message: 'invalid cursor' },
+          { status: 400 },
+        );
+      }
+      const idx = filtered.findIndex((j) => j.id === lastId);
+      startIdx = idx === -1 ? filtered.length : idx + 1;
+    }
+
+    const slice = filtered.slice(startIdx, startIdx + size);
+    const hasNext = startIdx + size < filtered.length;
+    const nextCursor =
+      hasNext && slice.length > 0 ? encodeCursor(slice[slice.length - 1].id) : null;
+
+    // 목록은 Summary 필드만 노출 (content/sourceUrl 등 detail 전용 제외).
+    const items = slice.map((j) => ({
+      id: j.id,
+      title: j.title,
+      organizationName: j.organizationName,
+      therapyArea: j.therapyArea,
+      therapyAreaLabel: j.therapyAreaLabel,
+      region: j.region,
+      regionLabel: j.regionLabel,
+      employmentType: j.employmentType,
+      employmentTypeLabel: j.employmentTypeLabel,
+      status: j.status,
+      dday: j.dday,
+      deadlineDate: j.deadlineDate,
+    }));
+
+    return HttpResponse.json({
+      success: true,
+      data: { items, nextCursor, hasNext, size },
+    });
+  }),
+
+  http.get(`${API}/job-posts/:id`, ({ params }) => {
+    const job = mockJobPosts.find((j) => j.id === Number(params.id));
+    if (!job) {
+      return HttpResponse.json({ success: false, code: 'NOT_FOUND' }, { status: 404 });
+    }
+    return HttpResponse.json({ success: true, data: job });
+  }),
+];

--- a/frontend/src/pages/jobpost/JobPostDetailPage.tsx
+++ b/frontend/src/pages/jobpost/JobPostDetailPage.tsx
@@ -1,0 +1,99 @@
+import { useParams, useLocation } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { ExternalLink } from 'lucide-react';
+import NarrowPage from '../../components/common/NarrowPage';
+import PageHeader from '../../components/common/PageHeader';
+import JobStatusBadge from '../../components/jobpost/JobStatusBadge';
+import { ddayLabel, isClosed } from '../../utils/jobPost';
+import { fetchJobPostDetail } from '../../api/jobPosts';
+
+export default function JobPostDetailPage() {
+  const { jobPostId } = useParams();
+  const location = useLocation();
+  const backTo = (location.state as { from?: string } | null)?.from ?? '/posts?tab=jobs';
+  const id = Number(jobPostId);
+
+  const {
+    data: job,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['job-post', id],
+    queryFn: ({ signal }) => fetchJobPostDetail(id, signal),
+    enabled: !Number.isNaN(id),
+  });
+
+  const closed = job ? isClosed(job.status, job.dday) : false;
+
+  return (
+    <NarrowPage>
+      <PageHeader title="구인공고" backTo={backTo} />
+
+      {isLoading && <p className="text-center py-16 text-gray-400">불러오는 중…</p>}
+      {isError && <p className="text-center py-16 text-destructive">공고를 불러오지 못했어요.</p>}
+
+      {job && (
+        <div className="px-5 pb-10">
+          {/* 상태 + D-day */}
+          <div className="flex items-center gap-2 mb-2 mt-1">
+            <JobStatusBadge status={job.status} dday={job.dday} />
+            {!closed && (
+              <span className="text-sm font-semibold text-emerald-600">
+                {ddayLabel(job.status, job.dday)}
+              </span>
+            )}
+          </div>
+
+          {/* 제목 + 기관 */}
+          <h1 className="text-xl font-bold text-neutral-950 mb-1">{job.title}</h1>
+          <p className="text-sm text-gray-500 mb-5">{job.organizationName}</p>
+
+          {/* 메타 */}
+          <dl className="space-y-2 text-sm border-y border-gray-100 py-4">
+            <MetaRow label="치료영역" value={job.therapyAreaLabel} />
+            <MetaRow label="지역" value={job.regionLabel} />
+            <MetaRow label="고용형태" value={job.employmentTypeLabel} />
+            {job.salaryText && <MetaRow label="급여" value={job.salaryText} />}
+            <MetaRow label="마감" value={job.deadlineDate} />
+          </dl>
+
+          {/* 본문 */}
+          <Section title="상세 내용" body={job.content} />
+          {job.qualification && <Section title="자격요건" body={job.qualification} />}
+          {job.preferred && <Section title="우대사항" body={job.preferred} />}
+
+          {/* 아웃링크 CTA — Phase 1엔 플랫폼 내 지원 없음, 원문으로 이동 */}
+          <a
+            href={job.sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-6 flex w-full items-center justify-center gap-1.5 rounded-lg bg-gray-900 py-3 text-sm font-medium text-white hover:bg-gray-800 transition-colors"
+          >
+            원문에서 지원하기
+            <ExternalLink size={16} />
+          </a>
+        </div>
+      )}
+    </NarrowPage>
+  );
+}
+
+function MetaRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex">
+      <dt className="w-16 shrink-0 font-semibold text-gray-600">{label}</dt>
+      <dd className="text-gray-700">{value}</dd>
+    </div>
+  );
+}
+
+function Section({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="mt-5">
+      <h2 className="text-sm font-bold text-gray-800 mb-1.5">{title}</h2>
+      <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap break-words">
+        {body}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/post/PostListPage.tsx
+++ b/frontend/src/pages/post/PostListPage.tsx
@@ -10,6 +10,7 @@ import { FILTER_CHIPS } from '../../constants/post';
 import WelcomeModal from '@/components/auth/WelcomeModal';
 import PostCard from '../../components/post/PostCard';
 import FilterChips from '../../components/common/FilterChips';
+import JobPostFeed from '../../components/jobpost/JobPostFeed';
 import PageHeader from '@/components/common/PageHeader';
 import UserMenu from '@/components/layout/UserMenu';
 import Pagination from '../../components/common/Pagination';
@@ -20,7 +21,7 @@ import { useScreenExit } from '@/hooks/useScreenExit';
 import { useWelcomeModal } from '@/hooks/useWelcomeModal';
 import { useQueryClient, type InfiniteData } from '@tanstack/react-query';
 
-type FeedTab = 'all' | 'following';
+type FeedTab = 'all' | 'following' | 'jobs';
 type FeedSort = 'LATEST' | 'POPULAR';
 
 function PostCardSkeleton() {
@@ -58,7 +59,9 @@ export default function PostListPage() {
   const currentPage = Number(searchParams.get('page') ?? '1');
 
   // 탭을 URL에 보존 — 상세 진입 후 뒤로가기 시 마지막 탭 복원(state면 'all'로 리셋됨).
-  const activeTab: FeedTab = searchParams.get('tab') === 'following' ? 'following' : 'all';
+  const tabParam = searchParams.get('tab');
+  const activeTab: FeedTab =
+    tabParam === 'following' ? 'following' : tabParam === 'jobs' ? 'jobs' : 'all';
   const [data, setData] = useState<PaginatedPosts | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -236,6 +239,7 @@ export default function PostListPage() {
   function handleTabChange(tab: FeedTab) {
     const next = new URLSearchParams(searchParams);
     if (tab === 'following') next.set('tab', 'following');
+    else if (tab === 'jobs') next.set('tab', 'jobs');
     else next.delete('tab');
     setSearchParams(next);
   }
@@ -326,6 +330,16 @@ export default function PostListPage() {
           >
             팔로우
           </button>
+          <button
+            onClick={() => handleTabChange('jobs')}
+            className={`flex-1 py-2 text-xs font-medium text-center transition-colors ${
+              activeTab === 'jobs'
+                ? 'text-neutral-950 border-b-2 border-black'
+                : 'text-gray-400 border-b border-gray-200'
+            }`}
+          >
+            구인
+          </button>
         </div>
       </div>
 
@@ -363,7 +377,9 @@ export default function PostListPage() {
       )}
 
       {/* 피드 콘텐츠 */}
-      {activeTab === 'all' ? (
+      {activeTab === 'jobs' ? (
+        <JobPostFeed />
+      ) : activeTab === 'all' ? (
         <div className="bg-white">
           {isInfiniteMode ? (
             <>

--- a/frontend/src/types/jobPost.ts
+++ b/frontend/src/types/jobPost.ts
@@ -1,0 +1,79 @@
+import type { TherapyArea } from './post';
+
+// 구인공고 — staging `/api/v1/job-posts` 실측 계약 기반 (AI 큐레이션 읽기 전용, Phase 1).
+// ⚠️ region/employmentType의 enum 문자열 값은 BE 미확정(staging 공고 0건 상태).
+//    서버가 `*Label` 필드를 동봉하므로 화면 표시엔 라벨을 그대로 쓰고,
+//    raw enum은 필터 쿼리 파라미터에만 쓰인다. 실데이터 연동 시 값 정합 재확인 필요.
+
+export type JobPostStatus = 'OPEN' | 'CLOSED';
+
+export type EmploymentType =
+  | 'FULL_TIME'
+  | 'CONTRACT'
+  | 'PART_TIME'
+  | 'FREELANCE'
+  | 'INTERN';
+
+export type JobRegion =
+  | 'SEOUL'
+  | 'BUSAN'
+  | 'DAEGU'
+  | 'INCHEON'
+  | 'GWANGJU'
+  | 'DAEJEON'
+  | 'ULSAN'
+  | 'SEJONG'
+  | 'GYEONGGI'
+  | 'GANGWON'
+  | 'CHUNGBUK'
+  | 'CHUNGNAM'
+  | 'JEONBUK'
+  | 'JEONNAM'
+  | 'GYEONGBUK'
+  | 'GYEONGNAM'
+  | 'JEJU'
+  | 'REMOTE'
+  | 'NATIONWIDE';
+
+// 목록(피드) 항목 — 서버가 라벨 동봉.
+export interface JobPostSummary {
+  id: number;
+  title: string;
+  organizationName: string;
+  therapyArea: TherapyArea;
+  therapyAreaLabel: string;
+  region: JobRegion;
+  regionLabel: string;
+  employmentType: EmploymentType;
+  employmentTypeLabel: string;
+  status: JobPostStatus;
+  // 서버 계산값. 양수=남은 일수, 0=오늘 마감, 음수=마감, null=상시/미정.
+  dday: number | null;
+  deadlineDate: string; // ISO date (YYYY-MM-DD)
+}
+
+// 상세 — Summary + 본문/자격/우대/급여/원문 링크.
+export interface JobPostDetail extends JobPostSummary {
+  content: string;
+  qualification?: string | null;
+  preferred?: string | null;
+  salaryText?: string | null;
+  sourceUrl: string; // AI 큐레이션 원문 URL. Phase 1의 "지원" = 이 링크로 아웃링크.
+  authorNickname?: string | null;
+}
+
+export interface CursorPagedJobPosts {
+  items: JobPostSummary[];
+  nextCursor: string | null;
+  hasNext: boolean;
+  size: number;
+}
+
+export interface JobPostListParams {
+  status?: JobPostStatus;
+  therapyArea?: TherapyArea;
+  region?: JobRegion;
+  employmentType?: EmploymentType;
+  cursor?: string;
+  size?: number;
+}

--- a/frontend/src/types/jobPost.ts
+++ b/frontend/src/types/jobPost.ts
@@ -1,9 +1,8 @@
 import type { TherapyArea } from './post';
 
 // 구인공고 — staging `/api/v1/job-posts` 실측 계약 기반 (AI 큐레이션 읽기 전용, Phase 1).
-// ⚠️ region/employmentType의 enum 문자열 값은 BE 미확정(staging 공고 0건 상태).
-//    서버가 `*Label` 필드를 동봉하므로 화면 표시엔 라벨을 그대로 쓰고,
-//    raw enum은 필터 쿼리 파라미터에만 쓰인다. 실데이터 연동 시 값 정합 재확인 필요.
+// region/employmentType enum 값은 staging `/v3/api-docs` 스키마로 실측 확정(2026-06-24).
+//   서버가 `*Label` 필드를 동봉하므로 화면 표시엔 라벨을 쓰고, raw enum은 필터 쿼리에만 쓴다.
 
 export type JobPostStatus = 'OPEN' | 'CLOSED';
 

--- a/frontend/src/utils/jobPost.ts
+++ b/frontend/src/utils/jobPost.ts
@@ -1,0 +1,14 @@
+import type { JobPostStatus } from '../types/jobPost';
+
+// 마감 판정: 명시 CLOSED 또는 dday 음수.
+export function isClosed(status: JobPostStatus, dday: number | null): boolean {
+  return status === 'CLOSED' || (dday !== null && dday < 0);
+}
+
+// D-day 라벨: 마감/상시/D-DAY/D-n.
+export function ddayLabel(status: JobPostStatus, dday: number | null): string {
+  if (isClosed(status, dday)) return '마감';
+  if (dday === null) return '상시모집';
+  if (dday === 0) return 'D-DAY';
+  return `D-${dday}`;
+}


### PR DESCRIPTION
## 개요
구인공고 **Phase 1**(AI 큐레이션 공고 **읽기 전용**). 홈피드에 "구인" 탭 추가 + 구인공고 상세 페이지 신규. staging `/job-posts` 실측 계약 기반이며, staging 공고가 0건이라 **MSW 더미 12건**으로 개발했습니다.

작성/수정/지원(Phase 2, MEL-59 회의 blocker)은 범위에서 제외했습니다.

## 브라우저 확인 방법 (더미 데이터)
staging엔 공고가 0건이라 더미를 보려면 MSW를 켜야 합니다.
1. `frontend/.env.local`에서 `VITE_MSW_ENABLED=true`로 변경 (앱 전체가 mock 모드로 전환됨 — 커밋하지 마세요)
2. `npm run dev`
3. 로그인 후 홈피드 → **"구인" 탭** → 카드 목록/필터/무한스크롤 → 카드 클릭 → 상세 → "원문에서 지원하기"(새 탭)
4. 확인 후 `.env.local` 원복

> MSW를 끈 채 staging으로 보면 빈 상태("조건에 맞는 구인공고가 없어요")가 정상입니다.

## 변경 파일
- **타입/상수/유틸**: `types/jobPost.ts`, `constants/jobPost.ts`, `utils/jobPost.ts`(dday 라벨/마감 판정)
- **데이터/목**: `mocks/data/jobPosts.ts`(더미 12), `mocks/handlers/jobPosts.handlers.ts`(목록 cursor+필터, 상세), `handlers/index.ts` 등록
- **API/훅**: `api/jobPosts.ts`, `hooks/useInfiniteJobPosts.ts`(구인 전용 cursor 무한스크롤)
- **컴포넌트**: `components/jobpost/{JobStatusBadge,JobPostCard,JobPostFeed}.tsx`
- **페이지/라우팅**: `pages/jobpost/JobPostDetailPage.tsx`, `App.tsx`(`/job-posts/:jobPostId`), `pages/post/PostListPage.tsx`(구인 탭 분기)

## 리뷰 포인트
1. **격리 설계** — 구인 탭은 `JobPostFeed`로 완전 격리. PostListPage는 탭 버튼 + `activeTab==='jobs'` 분기만 추가, 기존 전체/팔로우 피드(PostSummary/useInfiniteFeed)는 무손상.
2. **응답 envelope** — 목록/상세 모두 `{ success, data }` 래핑(피드와 동일). `axiosInstance` 인터셉터가 unwrap하지만 `res.data?.data ?? res.data`로 방어.
3. **cursor 페이지네이션** — 기존 page-based 피드와 다른 경로. `useInfiniteFeed` 일반화 대신 별도 훅(메모리 권고안). MSW 핸들러가 `nextCursor/hasNext`를 실제로 시뮬.

## 의도된 한계 (Phase 1 범위)
- 작성/수정/삭제/지원/검색/정렬 토글 **미구현**(BE API 없음 또는 Phase 2).
- 뒤로가기 시 **필터/스크롤 복원 미지원**(필터는 로컬 state).
- 상세 라우트는 `/posts`와 동일하게 `AuthRoute` 하위 — 게스트 노출 여부는 **MEL-59 #3 결정 대기**.

## BE 연동 시 확인 (enum은 실측 확정됨)
- **region(19종)·employmentType(5종)·status(OPEN/CLOSED) enum = staging `/v3/api-docs`로 실측 확정**(2026-06-24). 구현 타입과 순서까지 정확히 일치 → 필터 enum 균열 리스크 없음. (주석 정정 커밋 `2a8e722`)
- ⚠️ 잔여 불확실(둘 다 staging 0건이라 미검증): ① `dday` 음수/null의 정확한 의미(utils 방어 처리) ② "모집중만" OFF(=`status` 미전송) 시 BE가 마감 공고를 포함하는지 (MSW는 포함으로 구현).

## 검증
- `tsc -b` 통과 ✅ / dev 서버 부팅 200 ✅
- 런타임 **시각 확인은 작성자 브라우저 QA 예정**(이 PR 머지 전)
