### PR TITLE
feat: 게시글 검색 무한스크롤 전환 + offset 폴백

### DIFF
--- a/frontend/src/api/posts.ts
+++ b/frontend/src/api/posts.ts
@@ -34,6 +34,72 @@ export async function fetchPosts(params: {
   return res.data;
 }
 
+// 게시글 검색 (무한스크롤) — GET /posts/search, RELEVANCE 정렬 전용.
+// BE 커서는 (lastScore, lastId) 2-값이지만 useInfiniteFeed는 단일 string 커서만 안다.
+// 그래서 어댑터에서 {nextScore, nextId}를 base64 문자열 1개로 인코딩/디코딩해
+// CursorPagedPosts 모양으로 맞춰주면 기존 무한스크롤 훅을 그대로 재사용할 수 있다.
+// keyword는 BE 필수 — 호출부(SearchPage)가 keyword 있을 때만 이 함수를 쓴다.
+interface SearchCursor {
+  lastScore: number;
+  lastId: number;
+}
+
+function encodeSearchCursor(c: SearchCursor): string {
+  return btoa(JSON.stringify(c));
+}
+
+function decodeSearchCursor(cursor: string): SearchCursor | null {
+  try {
+    const parsed = JSON.parse(atob(cursor));
+    if (typeof parsed.lastScore === 'number' && typeof parsed.lastId === 'number') {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchSearch(params: {
+  keyword: string;
+  therapyArea?: TherapyArea;
+  postType?: PostType;
+  cursor?: string | null;
+  size?: number;
+  signal?: AbortSignal;
+}): Promise<CursorPagedPosts> {
+  const { keyword, therapyArea, postType, cursor, size, signal } = params;
+  // 첫 페이지는 lastScore/lastId 둘 다 생략(BE 규약). 커서가 있으면 풀어서 두 값으로 전달.
+  const decoded = cursor ? decodeSearchCursor(cursor) : null;
+  const res = await axiosInstance.get('/posts/search', {
+    params: {
+      keyword,
+      ...(therapyArea ? { therapyArea } : {}),
+      ...(postType ? { postType } : {}),
+      ...(decoded ? { lastScore: decoded.lastScore, lastId: decoded.lastId } : {}),
+      ...(size ? { size } : {}),
+    },
+    signal,
+  });
+  // 응답 형태가 피드와 다름: { success, data: { data:[아이템], meta:{hasNextData,nextScore,nextId} } }.
+  // 주의: axiosInstance 인터셉터가 success===true면 이미 한 겹(`{success,data}`→`data`) 벗겨준다.
+  //       검색 응답은 그 안쪽 객체에도 `data` 키가 있어서 fetchFeed식 `res.data?.data ?? res.data`로
+  //       풀면 아이템 배열까지 한 겹 더 벗겨져 buggy. envelope 의미대로 success 유무로 분기한다.
+  const body = res.data?.success === true ? res.data.data : res.data;
+  const meta = body?.meta ?? {};
+  const hasNext = meta.hasNextData ?? false;
+  return {
+    items: body?.data ?? [],
+    // 다음 페이지가 있을 때만 (nextScore, nextId)를 단일 커서로 인코딩. 없으면 null로 잠금.
+    nextCursor:
+      hasNext && typeof meta.nextScore === 'number' && typeof meta.nextId === 'number'
+        ? encodeSearchCursor({ lastScore: meta.nextScore, lastId: meta.nextId })
+        : null,
+    hasNext,
+    size: size ?? (body?.data?.length ?? 0),
+  };
+}
+
 export async function fetchFeed(params: {
   cursor?: string;
   size?: number;

--- a/frontend/src/mocks/handlers/posts.handlers.ts
+++ b/frontend/src/mocks/handlers/posts.handlers.ts
@@ -136,6 +136,50 @@ export const postsHandlers = [
     });
   }),
 
+  // 게시글 검색 (무한스크롤) — RELEVANCE 전용, (lastScore, lastId) 2-값 커서.
+  // 반드시 `/posts/:postId` 앞에 등록 (안 그러면 :postId="search"로 가로채임).
+  // 응답 envelope이 feed와 다름: data.data[](아이템) + data.meta{hasNextData,nextScore,nextId}.
+  http.get(`${API}/posts/search`, ({ request }) => {
+    const url = new URL(request.url);
+    const keyword = url.searchParams.get('keyword') ?? '';
+    const therapyArea = url.searchParams.get('therapyArea');
+    const rawSize = Number(url.searchParams.get('size') ?? '10');
+    const size = Math.min(50, Math.max(1, isNaN(rawSize) ? 10 : rawSize));
+    const lastScore = url.searchParams.get('lastScore');
+    const lastId = url.searchParams.get('lastId');
+
+    // 관련도 점수(목): score=id로 단순화. 정렬 = (score desc, id desc) = 커서 비교 기준.
+    const pool = mockFeedItems
+      .filter((p) => (therapyArea ? p.therapyArea === therapyArea : true))
+      .filter((p) => (keyword ? p.contentPreview.includes(keyword) : true))
+      .map((p) => ({ item: p, score: p.id }));
+    pool.sort((a, b) => b.score - a.score || b.item.id - a.item.id);
+
+    let startIdx = 0;
+    if (lastScore !== null && lastId !== null) {
+      const s = Number(lastScore);
+      const i = Number(lastId);
+      const idx = pool.findIndex((p) => p.score === s && p.item.id === i);
+      startIdx = idx === -1 ? pool.length : idx + 1;
+    }
+
+    const slice = pool.slice(startIdx, startIdx + size);
+    const hasNextData = startIdx + size < pool.length;
+    const last = slice[slice.length - 1];
+
+    return HttpResponse.json({
+      success: true,
+      data: {
+        data: slice.map((p) => p.item),
+        meta: {
+          hasNextData,
+          nextScore: hasNextData && last ? last.score : null,
+          nextId: hasNextData && last ? last.item.id : null,
+        },
+      },
+    });
+  }),
+
   http.get(`${API}/posts/:postId`, ({ params }) => {
     const post = mockPosts.find((p) => p.id === Number(params.postId));
     if (!post) return HttpResponse.json({ code: 'NOT_FOUND' }, { status: 404 });

--- a/frontend/src/pages/search/SearchPage.tsx
+++ b/frontend/src/pages/search/SearchPage.tsx
@@ -3,8 +3,9 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ArrowLeft, Search } from 'lucide-react';
 import PostCard from '../../components/post/PostCard';
 import FilterChips from '../../components/common/FilterChips';
-import { fetchPosts } from '../../api/posts';
-import type { TherapyArea, PostSort, PostSummary } from '../../types/post';
+import { fetchPosts, fetchSearch } from '../../api/posts';
+import { useInfiniteFeed } from '@/hooks/useInfiniteFeed';
+import type { TherapyArea, PaginatedPosts } from '../../types/post';
 import Pagination from '../../components/common/Pagination';
 
 export default function SearchPage() {
@@ -13,51 +14,89 @@ export default function SearchPage() {
 
   const inputRef = useRef<HTMLInputElement>(null);
   const [therapyArea, setTherapyArea] = useState<TherapyArea | ''>('');
-  const sortType: PostSort = 'LATEST';
-  const [results, setResults] = useState<PostSummary[] | null>(null);
-  const [loading, setLoading] = useState(false);
+  // 검색 실행 시점에 확정된 키워드. 입력 중 값이 아니라 "제출된" 값만 데이터 페치를 움직인다.
+  const [submittedKeyword, setSubmittedKeyword] = useState('');
   const [searched, setSearched] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
+  // 무한스크롤(/posts/search) 호출 실패 시 offset(/posts)으로 폴백하는 스위치.
+  const [feedFailed, setFeedFailed] = useState(false);
 
-  // 현재 검색 키워드 (검색 실행 시점에 확정된 값)
-  const keywordRef = useRef('');
+  // 모드 결정: 검색어가 있고 무한스크롤이 실패하지 않았으면 무한스크롤, 그 외엔 offset.
+  // - 검색어 있음           → /posts/search (RELEVANCE, 커서, 무한스크롤)  ← 기본
+  // - 검색어 있는데 실패     → /posts (sortType=RELEVANCE, offset)         ← 에러 폴백
+  // - 검색어 없이 필터만     → /posts (LATEST, offset)                     ← keyword 필수라 search 불가
+  const hasKeyword = submittedKeyword.trim().length > 0;
+  const isInfiniteMode = hasKeyword && !feedFailed;
 
-  async function doSearch(keyword: string, page: number) {
-    // 초기 마운트 보호: 검색어/필터 둘 다 비어있고 아직 검색 이력 없으면 호출 생략.
-    // 첫 검색 후에는 "전체"(therapyArea='') 리셋도 정상 재조회되도록 허용.
-    if (!keyword && !therapyArea && !searched) return;
-    setLoading(true);
-    setSearched(true);
-    setError(null);
-    try {
-      const data = await fetchPosts({
+  // ── 무한스크롤 (검색어 모드) ────────────────────────────────
+  // queryKey에 keyword/therapyArea를 넣어 검색 조건이 바뀌면 별개 캐시로 재조회.
+  // fetchSearch 어댑터가 2-값 커서(score,id)를 단일 문자열로 감싸 useInfiniteFeed가 그대로 먹는다.
+  const infinite = useInfiniteFeed({
+    queryKey: ['post-search', { keyword: submittedKeyword, therapyArea }],
+    fetchPage: ({ pageParam, signal }) =>
+      fetchSearch({
+        keyword: submittedKeyword,
         ...(therapyArea ? { therapyArea } : {}),
-        ...(keyword ? { keyword } : {}),
-        sortType,
-        page: page - 1,
+        cursor: pageParam,
         size: 10,
-      });
-      setResults(data.items ?? []);
-      setTotalPages(data.totalPages ?? 1);
-      setCurrentPage(page);
-    } catch {
-      setResults([]);
-      setError('검색 중 오류가 발생했습니다.');
-    } finally {
-      setLoading(false);
-    }
-  }
+        signal,
+      }),
+    enabled: isInfiniteMode,
+    onError: () => setFeedFailed(true),
+  });
 
+  // ── offset (필터-only / 무한스크롤 폴백 모드) ──────────────────
+  const [offsetData, setOffsetData] = useState<PaginatedPosts | null>(null);
+  const [offsetLoading, setOffsetLoading] = useState(false);
+  const [offsetError, setOffsetError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  useEffect(() => {
+    if (isInfiniteMode) return; // 무한스크롤이 담당
+    // 초기 마운트 보호: 검색어/필터 둘 다 없고 검색 이력도 없으면 호출 생략.
+    if (!hasKeyword && !therapyArea && !searched) return;
+    setOffsetLoading(true);
+    setOffsetError(null);
+    fetchPosts({
+      ...(therapyArea ? { therapyArea } : {}),
+      ...(hasKeyword ? { keyword: submittedKeyword } : {}),
+      // 검색어가 있는 폴백 경로는 관련도순, 필터-only는 최신순.
+      sortType: hasKeyword ? 'RELEVANCE' : 'LATEST',
+      page: currentPage - 1,
+      size: 10,
+    })
+      .then(setOffsetData)
+      .catch(() => {
+        setOffsetData(null);
+        setOffsetError('검색 중 오류가 발생했습니다.');
+      })
+      .finally(() => setOffsetLoading(false));
+  }, [isInfiniteMode, hasKeyword, submittedKeyword, therapyArea, currentPage, searched]);
+
+  // ── 무한스크롤 sentinel ──────────────────────────────────────
+  const { loadMore } = infinite;
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!isInfiniteMode) return;
+    const node = sentinelRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { rootMargin: '200px' },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [isInfiniteMode, loadMore]);
+
+  // ── 검색 실행 ────────────────────────────────────────────────
   function executeSearch() {
     const value = inputRef.current?.value.trim() ?? '';
-    keywordRef.current = value;
-    if (value) {
-      setSearchParams({ q: value });
-    }
+    setSubmittedKeyword(value);
+    setFeedFailed(false); // 새 검색마다 폴백 스위치 리셋
     setCurrentPage(1);
-    doSearch(value, 1);
+    setSearched(true);
+    setSearchParams(value ? { q: value } : {});
   }
 
   function handleSubmit(e: React.FormEvent) {
@@ -66,28 +105,33 @@ export default function SearchPage() {
     requestAnimationFrame(() => executeSearch());
   }
 
+  function handleTherapyAreaChange(value: TherapyArea | '') {
+    setTherapyArea(value);
+    setFeedFailed(false);
+    setCurrentPage(1);
+    setSearched(true);
+  }
+
   function handlePageChange(page: number) {
-    doSearch(keywordRef.current, page);
+    setCurrentPage(page);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 
   // URL ?q= 파라미터로 진입 시 자동 검색
   useEffect(() => {
     const q = searchParams.get('q');
-    if (q && inputRef.current) {
-      inputRef.current.value = q;
-      keywordRef.current = q;
-      doSearch(q, 1);
+    if (q) {
+      if (inputRef.current) inputRef.current.value = q;
+      setSubmittedKeyword(q);
+      setSearched(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // 필터 변경 시 검색 실행 (검색어 없어도 필터만으로 트리거)
-  // 초기 마운트는 doSearch 가드에서 흡수.
-  useEffect(() => {
-    doSearch(keywordRef.current, 1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [therapyArea]);
+  // ── 표시용 통합 변수 (모드별 소스 선택) ────────────────────────
+  const items = isInfiniteMode ? infinite.items : offsetData?.items ?? [];
+  const loading = isInfiniteMode ? infinite.isLoading : offsetLoading;
+  const error = isInfiniteMode ? infinite.error : offsetError;
 
   return (
     <div className="max-w-3xl mx-auto pb-20 md:pb-8">
@@ -124,7 +168,7 @@ export default function SearchPage() {
 
         {/* 카테고리 필터 칩 */}
         <div className="px-4 pt-2 pb-4">
-          <FilterChips value={therapyArea} onChange={setTherapyArea} />
+          <FilterChips value={therapyArea} onChange={handleTherapyAreaChange} />
         </div>
       </div>
 
@@ -134,24 +178,32 @@ export default function SearchPage() {
 
         {!loading && error && <p className="text-center text-red-500 text-sm py-12">{error}</p>}
 
-        {!loading && !error && searched && results?.length === 0 && (
+        {!loading && !error && searched && items.length === 0 && (
           <p className="text-center text-gray-400 text-sm py-12">검색 결과가 없습니다</p>
         )}
 
-        {!loading && results?.map((post) => <PostCard key={post.id} post={post} />)}
+        {!loading && items.map((post) => <PostCard key={post.id} post={post} />)}
 
         {!searched && !loading && (
-          <p className="text-[#6d7685] text-lg font-bold p-6">
-            시그널을 찾아보세요!
-          </p>
+          <p className="text-[#6d7685] text-lg font-bold p-6">시그널을 찾아보세요!</p>
         )}
       </div>
 
-      {/* 페이지네이션 */}
-      {searched && !loading && totalPages > 1 && (
+      {/* 무한스크롤 모드: sentinel + 추가 로딩 표시 */}
+      {isInfiniteMode && (
+        <>
+          <div ref={sentinelRef} aria-hidden className="h-1" />
+          {infinite.isFetchingMore && (
+            <p className="text-center text-gray-400 text-sm py-6">더 불러오는 중...</p>
+          )}
+        </>
+      )}
+
+      {/* offset 모드: 페이지네이션 */}
+      {!isInfiniteMode && searched && !loading && (offsetData?.totalPages ?? 1) > 1 && (
         <Pagination
           currentPage={currentPage}
-          totalPages={totalPages}
+          totalPages={offsetData?.totalPages ?? 1}
           onPageChange={handlePageChange}
         />
       )}

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -1,4 +1,5 @@
-export type PostSort = 'LATEST' | 'MOST_VIEWED';
+// RELEVANCE는 keyword 검색 시 관련도순. /posts(offset)·/posts/search(cursor) 모두 BE 지원.
+export type PostSort = 'LATEST' | 'MOST_VIEWED' | 'RELEVANCE';
 export type PostType = 'COMMUNITY' | 'RESOURCE' | 'CONCERN_CARD';
 export type Visibility = 'PUBLIC' | 'PRIVATE';
 


### PR DESCRIPTION
## 개요

게시글 검색을 offset 페이지네이션에서 무한스크롤(RELEVANCE 커서)로 전환합니다. BE가 검색용 무한스크롤 엔드포인트(`/posts/search`)를 의도했는데 FE가 offset(`/posts`)을 쓰고 있다고 알려와 시작된 작업입니다.

## 변경 사항

- **모드 분기** (`SearchPage.tsx`): 검색어가 있으면 `/posts/search`(RELEVANCE, 커서, 무한스크롤), 검색어 없이 필터칩만 있으면 `/posts`(LATEST, offset). `/posts/search`는 keyword가 필수라 검색어 없는 경우는 무조건 offset으로 갑니다.
- **`fetchSearch` 어댑터** (`api/posts.ts`): BE 커서가 `(lastScore, lastId)` 2-값인데 `useInfiniteFeed`는 단일 string 커서만 다룹니다. 두 값을 base64 문자열 1개로 인코딩/디코딩해 기존 무한스크롤 훅을 그대로 재사용합니다.
- **에러 폴백**: 무한스크롤 호출이 실패하면 `feedFailed` 스위치로 offset(`sortType=RELEVANCE`)으로 폴백합니다.
- **이중 unwrap 버그 수정**: axios 인터셉터가 `{success, data}` 봉투를 이미 한 겹 벗기는데, 검색 응답은 그 안쪽 객체에도 `data` 키가 있어 `res.data?.data ?? res.data`로 풀면 아이템 배열까지 한 겹 더 벗겨집니다. `success` 유무로 분기하도록 수정했습니다.
- **MSW**: `/posts/search` 핸들러 추가(`/posts/:postId`보다 앞에 등록), `PostSort`에 `RELEVANCE` 추가.

## 셀프 QA (실 staging, MSW OFF)

- **QA-1 무한스크롤 2페이지 자동로드** ✅ — 첫 요청은 `keyword&size`만, 다음 요청에 `lastScore&lastId` 부착되는 커서 왕복 확인. 응답 봉투가 가정과 정확히 일치(`data.data[]` + `data.meta.{hasNextData, nextScore, nextId}`)함을 실 staging 응답으로 검증. 마지막 페이지 `hasNextData:false`에서 커서가 null로 잠겨 정상 종료.
- **QA-2 필터-only offset** ✅ — 검색어 없이 필터칩만 누르면 `/posts?sortType=LATEST&page=0`로 빠지고 페이지네이션으로 동작.

## 참고

- AI 작성 코드입니다(인지부채 HIGH). 메커니즘·자기점검은 메모리 `project_search_infinite_scroll_2026_06_24`에 박제되어 있습니다.
- 의도된 한계: 검색어 없는 필터-only는 무한스크롤 불가(BE keyword 필수), 이때만 offset.
