### PR TITLE
feat: 구인공고 수정·삭제 기능 (Phase 2)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import PostDetailPage from './pages/post/PostDetailPage';
 import PostCreatePage from './pages/post/PostCreatePage';
 import JobPostDetailPage from './pages/jobpost/JobPostDetailPage';
 import JobPostCreatePage from './pages/jobpost/JobPostCreatePage';
+import JobPostEditPage from './pages/jobpost/JobPostEditPage';
 import PostEditPage from './pages/post/PostEditPage';
 import CommentWritePage from './pages/post/CommentWritePage';
 import CommentDetailPage from './pages/post/CommentDetailPage';
@@ -102,6 +103,7 @@ function App() {
             <Route path="/posts/new" element={<PostCreatePage />} />
             <Route path="/job-posts/new" element={<JobPostCreatePage />} />
             <Route path="/job-posts/:jobPostId" element={<JobPostDetailPage />} />
+            <Route path="/job-posts/:jobPostId/edit" element={<JobPostEditPage />} />
             <Route path="/posts/:postId/edit" element={<PostEditPage />} />
             <Route path="/search" element={<SearchPage />} />
             <Route path="/notifications" element={<NotificationPage />} />

--- a/frontend/src/api/jobPosts.ts
+++ b/frontend/src/api/jobPosts.ts
@@ -4,6 +4,7 @@ import type {
   JobPostCreatePayload,
   JobPostDetail,
   JobPostListParams,
+  JobPostUpdatePayload,
 } from '../types/jobPost';
 
 // 구인공고 목록 — cursor 페이지네이션 + 필터(status/therapyArea/region/employmentType).
@@ -32,4 +33,18 @@ export async function createJobPost(
 ): Promise<JobPostDetail> {
   const res = await axiosInstance.post('/job-posts', payload);
   return res.data?.data ?? res.data;
+}
+
+// 수정 — Phase 2. PATCH /job-posts/{id}. 응답은 갱신된 상세(create와 동일 형태).
+export async function updateJobPost(
+  id: number,
+  payload: JobPostUpdatePayload,
+): Promise<JobPostDetail> {
+  const res = await axiosInstance.patch(`/job-posts/${id}`, payload);
+  return res.data?.data ?? res.data;
+}
+
+// 삭제 — Phase 2. DELETE /job-posts/{id}. 응답 바디 없음(204).
+export async function deleteJobPost(id: number): Promise<void> {
+  await axiosInstance.delete(`/job-posts/${id}`);
 }

--- a/frontend/src/components/jobpost/JobPostActions.tsx
+++ b/frontend/src/components/jobpost/JobPostActions.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Pencil, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { useJobPostMutations } from '../../hooks/useJobPostMutations';
+import type { JobPostDetail } from '../../types/jobPost';
+
+interface JobPostActionsProps {
+  job: JobPostDetail;
+}
+
+// 상세 하단 수정/삭제 액션바. 권한은 BE가 내려준 canEdit로 분기 — 없거나 false면 아무것도 안 그림.
+// 마감(close)은 이번 스코프 밖(2026-07-06) — 필요 시 여기에 '마감' 버튼을 추가하고
+// job.canClose 게이트 + close mutation을 붙이면 됨(자리만 남겨둠).
+export default function JobPostActions({ job }: JobPostActionsProps) {
+  const navigate = useNavigate();
+  const { remove } = useJobPostMutations();
+  const [confirming, setConfirming] = useState(false);
+
+  if (!job.canEdit) return null;
+
+  const handleDelete = async () => {
+    try {
+      await remove.mutateAsync(job.id);
+      toast.success('공고를 삭제했어요.');
+      navigate('/posts?tab=jobs');
+    } catch (err) {
+      console.error('[jobpost] deleteJobPost 실패(JobPostActions)', err);
+      toast.error('삭제에 실패했어요. 다시 시도해주세요.');
+      setConfirming(false);
+    }
+  };
+
+  return (
+    <div className="mt-6 border-t border-gray-100 pt-4">
+      {confirming ? (
+        // 2단계 확인 — 오삭제 방지. window.confirm 대신 인라인으로 흐름 유지.
+        <div className="flex flex-col gap-2">
+          <p className="text-sm text-gray-700">이 공고를 삭제할까요? 되돌릴 수 없어요.</p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={remove.isPending}
+              className="flex-1 rounded-lg bg-red-500 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-600 disabled:opacity-50"
+            >
+              {remove.isPending ? '삭제 중…' : '삭제'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              disabled={remove.isPending}
+              className="flex-1 rounded-lg border border-gray-200 py-2.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 disabled:opacity-50"
+            >
+              취소
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() =>
+              navigate(`/job-posts/${job.id}/edit`, { state: { from: '/posts?tab=jobs' } })
+            }
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-gray-200 py-2.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+          >
+            <Pencil size={15} />
+            수정
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            className="flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-red-200 py-2.5 text-sm font-medium text-red-500 transition-colors hover:bg-red-50"
+          >
+            <Trash2 size={15} />
+            삭제
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/jobpost/JobPostForm.tsx
+++ b/frontend/src/components/jobpost/JobPostForm.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
-import type { EmploymentType, JobRegion } from '../../types/jobPost';
+import type {
+  EmploymentType,
+  JobRegion,
+  JobPostCreatePayload,
+} from '../../types/jobPost';
 import type { TherapyArea } from '../../types/post';
 import {
   EMPLOYMENT_TYPE_LABELS,
@@ -8,31 +12,55 @@ import {
   ALWAYS_OPEN_DEADLINE,
 } from '../../constants/jobPost';
 import { THERAPY_CHIPS } from '../../constants/post';
-import { createJobPost } from '../../api/jobPosts';
-import { isHttpUrl } from '../../utils/jobPost';
+import { isHttpUrl, type JobPostFormValues } from '../../utils/jobPost';
 
 const NAME_MAX = 100;
 const CONTENT_MAX = 2000;
 
+const EMPTY_VALUES: JobPostFormValues = {
+  organizationName: '',
+  therapyArea: null,
+  region: '',
+  employmentType: null,
+  alwaysRecruiting: false,
+  deadlineDate: '',
+  content: '',
+  qualification: '',
+  preferred: '',
+  salaryText: '',
+  sourceUrl: '',
+};
+
 interface JobPostFormProps {
-  // 작성 성공 후 호출 — 컨테이너(JobPostCreatePage)가 캐시 무효화 + 상세로 navigate.
-  onSuccess: (id: number) => void;
+  // 미지정=작성(빈 폼), 지정=수정(prefill).
+  initialValues?: JobPostFormValues;
+  submitLabel?: string;
+  // 검증 통과 후 정규화된 payload로 호출 — 컨테이너가 생성/수정 mutation + navigate 담당.
+  // 실패 시 throw하면 폼이 잡아 에러 문구를 노출(제출 상태 해제).
+  onSubmit: (payload: JobPostCreatePayload) => Promise<void>;
 }
 
-// Phase 2 구인공고 작성 폼. ConcernForm의 plain-useState 패턴을 따름(폼 라이브러리 미사용).
-// 페이지 chrome(헤더/래퍼)은 상위 JobPostCreatePage가 소유, 이 컴포넌트는 필드 + 제출만 담당.
-export default function JobPostForm({ onSuccess }: JobPostFormProps) {
-  const [organizationName, setOrganizationName] = useState('');
-  const [therapyArea, setTherapyArea] = useState<TherapyArea | null>(null);
-  const [region, setRegion] = useState<JobRegion | ''>('');
-  const [employmentType, setEmploymentType] = useState<EmploymentType | null>(null);
-  const [alwaysRecruiting, setAlwaysRecruiting] = useState(false);
-  const [deadlineDate, setDeadlineDate] = useState('');
-  const [content, setContent] = useState('');
-  const [qualification, setQualification] = useState('');
-  const [preferred, setPreferred] = useState('');
-  const [salaryText, setSalaryText] = useState('');
-  const [sourceUrl, setSourceUrl] = useState('');
+// Phase 2 구인공고 작성/수정 공용 폼. ConcernForm의 plain-useState 패턴(폼 라이브러리 미사용).
+// 페이지 chrome(헤더/래퍼)은 상위 페이지가 소유, 이 컴포넌트는 필드 + 검증 + 제출 위임만 담당.
+export default function JobPostForm({
+  initialValues,
+  submitLabel = '공고 등록',
+  onSubmit,
+}: JobPostFormProps) {
+  const init = initialValues ?? EMPTY_VALUES;
+  const [organizationName, setOrganizationName] = useState(init.organizationName);
+  const [therapyArea, setTherapyArea] = useState<TherapyArea | null>(init.therapyArea);
+  const [region, setRegion] = useState<JobRegion | ''>(init.region);
+  const [employmentType, setEmploymentType] = useState<EmploymentType | null>(
+    init.employmentType,
+  );
+  const [alwaysRecruiting, setAlwaysRecruiting] = useState(init.alwaysRecruiting);
+  const [deadlineDate, setDeadlineDate] = useState(init.deadlineDate);
+  const [content, setContent] = useState(init.content);
+  const [qualification, setQualification] = useState(init.qualification);
+  const [preferred, setPreferred] = useState(init.preferred);
+  const [salaryText, setSalaryText] = useState(init.salaryText);
+  const [sourceUrl, setSourceUrl] = useState(init.sourceUrl);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -72,7 +100,7 @@ export default function JobPostForm({ onSuccess }: JobPostFormProps) {
     setSubmitting(true);
     setError(null);
     try {
-      const created = await createJobPost({
+      await onSubmit({
         organizationName: organizationName.trim(),
         content: content.trim(),
         therapyArea,
@@ -86,10 +114,10 @@ export default function JobPostForm({ onSuccess }: JobPostFormProps) {
         qualification: qualification.trim() || undefined,
         preferred: preferred.trim() || undefined,
       });
-      onSuccess(created.id);
+      // 성공 후 네비게이션/캐시 무효화는 컨테이너(onSubmit) 책임 — 폼은 여기서 끝.
     } catch (err) {
-      console.error('[jobpost] createJobPost 실패(JobPostForm)', err);
-      setError('구인공고 작성에 실패했습니다. 다시 시도해주세요.');
+      console.error('[jobpost] 공고 저장 실패(JobPostForm)', err);
+      setError('저장에 실패했습니다. 다시 시도해주세요.');
     } finally {
       setSubmitting(false);
     }
@@ -255,7 +283,7 @@ export default function JobPostForm({ onSuccess }: JobPostFormProps) {
         aria-disabled={!canSubmit}
         className="mt-2 w-full rounded-lg bg-gray-900 py-3 text-sm font-semibold text-white transition-colors hover:bg-black aria-disabled:bg-gray-200 aria-disabled:text-gray-400 aria-disabled:hover:bg-gray-200 aria-disabled:cursor-not-allowed"
       >
-        {submitting ? '등록 중…' : '공고 등록'}
+        {submitting ? '저장 중…' : submitLabel}
       </button>
     </div>
   );

--- a/frontend/src/hooks/useJobPostMutations.ts
+++ b/frontend/src/hooks/useJobPostMutations.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  createJobPost,
+  updateJobPost,
+  deleteJobPost,
+} from '../api/jobPosts';
+import type {
+  JobPostCreatePayload,
+  JobPostUpdatePayload,
+} from '../types/jobPost';
+
+// 구인공고 쓰기(생성/수정/삭제) mutation 모음 + 캐시 무효화를 한 곳에 모음.
+//
+// 캐시 키 두 갈래를 왜 나눠 무효화하는지:
+//   - ['job-posts']       = 목록(무한스크롤 피드). 생성/수정/삭제 모두 목록 스냅샷이 바뀌므로 항상 stale.
+//   - ['job-post', id]    = 개별 상세. 수정은 그 상세를 갱신하므로 invalidate(재조회),
+//                           삭제는 상세가 사라지므로 remove(재조회하면 404이니 캐시에서 제거).
+// 생성은 아직 상세 캐시가 없으니 목록만 무효화하면 됨.
+export function useJobPostMutations() {
+  const qc = useQueryClient();
+
+  const create = useMutation({
+    mutationFn: (payload: JobPostCreatePayload) => createJobPost(payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['job-posts'] });
+    },
+  });
+
+  const update = useMutation({
+    mutationFn: ({ id, payload }: { id: number; payload: JobPostUpdatePayload }) =>
+      updateJobPost(id, payload),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: ['job-posts'] });
+      qc.invalidateQueries({ queryKey: ['job-post', id] });
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: number) => deleteJobPost(id),
+    onSuccess: (_data, id) => {
+      qc.invalidateQueries({ queryKey: ['job-posts'] });
+      // 삭제된 상세는 재조회하면 404 → 무효화(재요청) 대신 캐시에서 제거.
+      qc.removeQueries({ queryKey: ['job-post', id] });
+    },
+  });
+
+  return { create, update, remove };
+}

--- a/frontend/src/mocks/data/jobPosts.ts
+++ b/frontend/src/mocks/data/jobPosts.ts
@@ -233,4 +233,6 @@ export const mockJobPosts: JobPostDetail[] = seeds.map((s) => ({
   preferred: s.preferred ?? null,
   salaryText: s.salaryText ?? null,
   authorNickname: 'Mellti AI',
+  // 목에선 항상 수정/삭제 가능하게 노출(dev에서 액션바 검증용). 실제 BE가 권한 판정해 내려줌.
+  canEdit: true,
 }));

--- a/frontend/src/mocks/handlers/jobPosts.handlers.ts
+++ b/frontend/src/mocks/handlers/jobPosts.handlers.ts
@@ -150,9 +150,74 @@ export const jobPostsHandlers = [
       salaryText: body.salaryText?.trim() || null,
       sourceUrl: body.sourceUrl.trim(),
       authorNickname: '나',
+      canEdit: true,
     };
 
     mockJobPosts.unshift(created);
     return HttpResponse.json({ success: true, data: created }, { status: 201 });
+  }),
+
+  // 수정(Update) — Phase 2. PATCH /job-posts/:id. 파생 필드(title/label/dday) 재계산 후 교체.
+  http.patch(`${API}/job-posts/:id`, async ({ params, request }) => {
+    const idx = mockJobPosts.findIndex((j) => j.id === Number(params.id));
+    if (idx === -1) {
+      return HttpResponse.json({ success: false, code: 'NOT_FOUND' }, { status: 404 });
+    }
+    const body = (await request.json()) as JobPostCreatePayload;
+
+    const required =
+      body?.organizationName?.trim() &&
+      body?.therapyArea &&
+      body?.region &&
+      body?.employmentType &&
+      body?.content?.trim() &&
+      body?.sourceUrl?.trim() &&
+      body?.deadlineDate;
+    if (!required) {
+      return HttpResponse.json(
+        { success: false, code: 'INVALID_INPUT', message: '필수 항목 누락' },
+        { status: 400 },
+      );
+    }
+
+    const deadlineDate = body.alwaysRecruiting ? ALWAYS_OPEN_DEADLINE : body.deadlineDate;
+    const alwaysOpen = body.alwaysRecruiting === true;
+    const therapyAreaLabel = THERAPY_AREA_LABELS[body.therapyArea] ?? body.therapyArea;
+    const employmentTypeLabel = EMPLOYMENT_TYPE_LABELS[body.employmentType];
+    const title = `${body.organizationName.trim()} ${therapyAreaLabel} ${employmentTypeLabel} 모집`;
+
+    // 기존 항목 기반으로 편집 필드만 덮어씀(id/status/authorNickname/canEdit 등은 유지).
+    const updated: JobPostDetail = {
+      ...mockJobPosts[idx],
+      title,
+      organizationName: body.organizationName.trim(),
+      therapyArea: body.therapyArea,
+      therapyAreaLabel,
+      region: body.region,
+      regionLabel: REGION_LABELS[body.region],
+      employmentType: body.employmentType,
+      employmentTypeLabel,
+      dday: computeDday(deadlineDate),
+      deadlineDate,
+      alwaysOpen,
+      content: body.content.trim(),
+      qualification: body.qualification?.trim() || null,
+      preferred: body.preferred?.trim() || null,
+      salaryText: body.salaryText?.trim() || null,
+      sourceUrl: body.sourceUrl.trim(),
+    };
+
+    mockJobPosts[idx] = updated;
+    return HttpResponse.json({ success: true, data: updated });
+  }),
+
+  // 삭제(Delete) — Phase 2. DELETE /job-posts/:id. 스토어에서 제거, 바디 없이 204.
+  http.delete(`${API}/job-posts/:id`, ({ params }) => {
+    const idx = mockJobPosts.findIndex((j) => j.id === Number(params.id));
+    if (idx === -1) {
+      return HttpResponse.json({ success: false, code: 'NOT_FOUND' }, { status: 404 });
+    }
+    mockJobPosts.splice(idx, 1);
+    return new HttpResponse(null, { status: 204 });
   }),
 ];

--- a/frontend/src/pages/jobpost/JobPostCreatePage.tsx
+++ b/frontend/src/pages/jobpost/JobPostCreatePage.tsx
@@ -1,25 +1,26 @@
 import { useNavigate } from 'react-router-dom';
-import { useQueryClient } from '@tanstack/react-query';
 import NarrowPage from '../../components/common/NarrowPage';
 import PageHeader from '../../components/common/PageHeader';
 import JobPostForm from '../../components/jobpost/JobPostForm';
+import { useJobPostMutations } from '../../hooks/useJobPostMutations';
+import type { JobPostCreatePayload } from '../../types/jobPost';
 
 // Phase 2 구인공고 작성 페이지. 숨긴 라우트(/job-posts/new) — 진입 버튼은 아직 노출 안 함(스테이징 검증용).
 // ADMIN 전용 작성 게이트는 보류(2026-07-03 결정): 이용자 소수라 우선순위 낮음.
 export default function JobPostCreatePage() {
   const navigate = useNavigate();
-  const qc = useQueryClient();
+  const { create } = useJobPostMutations();
 
-  const handleSuccess = (id: number) => {
-    // 목록 캐시를 stale 처리 → 새 공고가 피드 상단에 반영되게. 이후 작성한 공고 상세로 이동.
-    qc.invalidateQueries({ queryKey: ['job-posts'] });
-    navigate(`/job-posts/${id}`, { state: { from: '/posts?tab=jobs' } });
+  // 캐시 무효화는 create mutation의 onSuccess가 담당(useJobPostMutations). 여기선 상세로 이동만.
+  const handleSubmit = async (payload: JobPostCreatePayload) => {
+    const created = await create.mutateAsync(payload);
+    navigate(`/job-posts/${created.id}`, { state: { from: '/posts?tab=jobs' } });
   };
 
   return (
     <NarrowPage>
       <PageHeader title="구인공고 작성" backTo="/posts?tab=jobs" />
-      <JobPostForm onSuccess={handleSuccess} />
+      <JobPostForm onSubmit={handleSubmit} />
     </NarrowPage>
   );
 }

--- a/frontend/src/pages/jobpost/JobPostDetailPage.tsx
+++ b/frontend/src/pages/jobpost/JobPostDetailPage.tsx
@@ -4,6 +4,7 @@ import { ExternalLink } from 'lucide-react';
 import NarrowPage from '../../components/common/NarrowPage';
 import PageHeader from '../../components/common/PageHeader';
 import JobStatusBadge from '../../components/jobpost/JobStatusBadge';
+import JobPostActions from '../../components/jobpost/JobPostActions';
 import { ddayLabel, deadlineText, isAlwaysOpen, isClosed, isHttpUrl } from '../../utils/jobPost';
 import { fetchJobPostDetail } from '../../api/jobPosts';
 
@@ -76,6 +77,9 @@ export default function JobPostDetailPage() {
               <ExternalLink size={16} />
             </a>
           )}
+
+          {/* 수정/삭제 액션 — 권한(canEdit) 있을 때만 렌더(컴포넌트 내부에서 게이트). */}
+          <JobPostActions job={job} />
         </div>
       )}
     </NarrowPage>

--- a/frontend/src/pages/jobpost/JobPostEditPage.tsx
+++ b/frontend/src/pages/jobpost/JobPostEditPage.tsx
@@ -1,0 +1,53 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import NarrowPage from '../../components/common/NarrowPage';
+import PageHeader from '../../components/common/PageHeader';
+import JobPostForm from '../../components/jobpost/JobPostForm';
+import { useJobPostMutations } from '../../hooks/useJobPostMutations';
+import { fetchJobPostDetail } from '../../api/jobPosts';
+import { jobPostToFormValues } from '../../utils/jobPost';
+import type { JobPostCreatePayload } from '../../types/jobPost';
+
+// Phase 2 구인공고 수정 페이지 — /job-posts/:jobPostId/edit.
+// 상세를 먼저 불러와 폼에 prefill한 뒤, 제출 시 update mutation으로 저장하고 상세로 복귀.
+export default function JobPostEditPage() {
+  const { jobPostId } = useParams();
+  const navigate = useNavigate();
+  const { update } = useJobPostMutations();
+  const id = Number(jobPostId);
+
+  const {
+    data: job,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['job-post', id],
+    queryFn: ({ signal }) => fetchJobPostDetail(id, signal),
+    enabled: !Number.isNaN(id),
+  });
+
+  // 캐시 무효화(목록 + 이 상세)는 update mutation onSuccess가 담당. 여기선 상세로 이동만.
+  const handleSubmit = async (payload: JobPostCreatePayload) => {
+    await update.mutateAsync({ id, payload });
+    navigate(`/job-posts/${id}`, { state: { from: '/posts?tab=jobs' } });
+  };
+
+  return (
+    <NarrowPage>
+      <PageHeader title="구인공고 수정" backTo={`/job-posts/${id}`} />
+
+      {isLoading && <p className="text-center py-16 text-gray-400">불러오는 중…</p>}
+      {isError && (
+        <p className="text-center py-16 text-destructive">공고를 불러오지 못했어요.</p>
+      )}
+
+      {job && (
+        <JobPostForm
+          initialValues={jobPostToFormValues(job)}
+          submitLabel="수정 완료"
+          onSubmit={handleSubmit}
+        />
+      )}
+    </NarrowPage>
+  );
+}

--- a/frontend/src/types/jobPost.ts
+++ b/frontend/src/types/jobPost.ts
@@ -62,6 +62,10 @@ export interface JobPostDetail extends JobPostSummary {
   salaryText?: string | null;
   sourceUrl: string; // AI 큐레이션 원문 URL. Phase 1의 "지원" = 이 링크로 아웃링크.
   authorNickname?: string | null;
+  // 권한 플래그(Phase 2) — BE가 상세 응답에 내려주는 "이 사용자가 수정/삭제할 수 있나".
+  // FE는 롤을 직접 판정하지 않고 이 값으로 수정·삭제 버튼 노출을 분기. BE 미배포 구간엔
+  // 응답에 없을 수 있어 optional — 없으면 버튼 미노출(JobPostActions가 falsy 처리).
+  canEdit?: boolean;
 }
 
 export interface CursorPagedJobPosts {
@@ -97,3 +101,8 @@ export interface JobPostCreatePayload {
   qualification?: string;
   preferred?: string;
 }
+
+// 수정(Update) 요청 바디 — staging 실측상 UpdateJobPostRequest는 CreateJobPostRequest와 동일 필드.
+// 별도 인터페이스로 두면 계약이 갈라질 때 create만 바꿔도 update가 따라오지 않아 drift 위험 →
+// 의도적으로 alias. 계약이 실제로 갈라지면 그때 독립 인터페이스로 분리.
+export type JobPostUpdatePayload = JobPostCreatePayload;

--- a/frontend/src/utils/jobPost.ts
+++ b/frontend/src/utils/jobPost.ts
@@ -1,4 +1,11 @@
-import type { JobPostStatus, JobPostSummary } from '../types/jobPost';
+import type {
+  EmploymentType,
+  JobPostDetail,
+  JobPostStatus,
+  JobPostSummary,
+  JobRegion,
+} from '../types/jobPost';
+import type { TherapyArea } from '../types/post';
 import { ALWAYS_OPEN_DEADLINE } from '../constants/jobPost';
 
 // 상시모집 판별 — BE alwaysOpen 우선, 미배포 구간엔 sentinel 날짜/ null dday로 방어적 폴백.
@@ -53,4 +60,41 @@ export function isHttpUrl(value: string): boolean {
   } catch {
     return false;
   }
+}
+
+// 작성/수정 공용 폼(JobPostForm)의 원시 필드 상태 shape.
+// payload와 다른 점: therapyArea/employmentType은 미선택(null)·region은 미선택('')을 표현하고,
+// alwaysRecruiting은 체크박스라 deadlineDate와 별도로 들고 감(제출 시 payload로 정규화).
+export interface JobPostFormValues {
+  organizationName: string;
+  therapyArea: TherapyArea | null;
+  region: JobRegion | '';
+  employmentType: EmploymentType | null;
+  alwaysRecruiting: boolean;
+  deadlineDate: string;
+  content: string;
+  qualification: string;
+  preferred: string;
+  salaryText: string;
+  sourceUrl: string;
+}
+
+// 수정 화면 prefill용 — 상세 응답을 폼 값으로 변환.
+// 상시모집이면 alwaysRecruiting=true로 켜고 deadlineDate는 비움(체크박스가 sentinel을 담당,
+// 실제 저장된 sentinel '9999-12-31'을 date input에 넣지 않으려는 것).
+export function jobPostToFormValues(job: JobPostDetail): JobPostFormValues {
+  const always = isAlwaysOpen(job);
+  return {
+    organizationName: job.organizationName,
+    therapyArea: job.therapyArea,
+    region: job.region,
+    employmentType: job.employmentType,
+    alwaysRecruiting: always,
+    deadlineDate: always ? '' : job.deadlineDate,
+    content: job.content,
+    qualification: job.qualification ?? '',
+    preferred: job.preferred ?? '',
+    salaryText: job.salaryText ?? '',
+    sourceUrl: job.sourceUrl,
+  };
 }


### PR DESCRIPTION
구인공고 Phase 2의 **수정·삭제** 기능. 작성(Create, #이전)에 이어 CRUD의 U/D 추가.
MSW 목 기반(BE PATCH/DELETE는 staging·prod 배포 확인됨, 실통신 미검증 → 어댑터 격리).

## 변경 요약
- **API/훅**: `updateJobPost`(PATCH)·`deleteJobPost`(DELETE) + `useJobPostMutations`(create/update/delete + 캐시 무효화 중앙화)
- **폼**: `JobPostForm`을 작성/수정 공용으로 리팩터 — API 호출을 폼 밖으로 빼고 `initialValues` prefill + `onSubmit` 위임
- **페이지/UI**: `JobPostEditPage`(`/job-posts/:id/edit`) + 상세 하단 `JobPostActions`(수정/삭제, `canEdit` 게이트, 삭제 2단계 확인)
- **MSW**: PATCH/DELETE 핸들러 + 목 데이터 `canEdit` 노출
- 마감(close)은 이번 스코프 밖(자리만 남김)

## ⚠️ 리뷰 포인트 (인지부채 — AI 생성, 나중에 본인 검토 대상)
1. **`useJobPostMutations`** — "왜 목록은 invalidate, 삭제 상세는 remove인가" (계획서상 원래 본인작성 대상)
2. **`JobPostForm` 리팩터** — create 경로가 보존됐는지 (onSubmit 위임 후 navigate 이동)
3. **`jobPostToFormValues`** — 상시모집 prefill 시 deadlineDate 비우는 이유

## 검증
tsc 0 / eslint 0 / build 0 (chunk size warning은 기존)