### PR TITLE
feat: 구인공고 작성 버튼 — 인증 치료사 노출 (Phase 2)

### DIFF
--- a/frontend/src/components/jobpost/JobPostFeed.tsx
+++ b/frontend/src/components/jobpost/JobPostFeed.tsx
@@ -1,14 +1,23 @@
 import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Plus } from 'lucide-react';
 import FilterChips from '../common/FilterChips';
 import JobPostCard from './JobPostCard';
 import { useInfiniteJobPosts } from '../../hooks/useInfiniteJobPosts';
 import { REGION_FILTER_OPTIONS, EMPLOYMENT_FILTER_OPTIONS } from '../../constants/jobPost';
+import { useAuthStore } from '../../stores/useAuthStore';
 import type { TherapyArea } from '../../types/post';
 import type { EmploymentType, JobRegion } from '../../types/jobPost';
 
 // 홈피드 "구인" 탭 본문. PostListPage의 PostSummary 머신과 격리 — 자체 데이터/필터/카드 소유.
 // 필터는 로컬 state(Phase 1). 뒤로가기 시 필터 복원은 미지원(범위 밖).
 export default function JobPostFeed() {
+  const navigate = useNavigate();
+  const user = useAuthStore((s) => s.user);
+  // 작성 진입은 인증 치료사(THERAPIST/ADMIN)만 — ProfilePage:157의 isVerified 컨벤션 재사용.
+  // 일반 USER/비로그인은 버튼 미노출. (2026-07-06 결정: 인증 치료사 자유 작성)
+  const canWrite = user?.role === 'THERAPIST' || user?.role === 'ADMIN';
+
   const [therapyArea, setTherapyArea] = useState<TherapyArea | ''>('');
   const [region, setRegion] = useState<JobRegion | ''>('');
   const [employmentType, setEmploymentType] = useState<EmploymentType | ''>('');
@@ -40,6 +49,20 @@ export default function JobPostFeed() {
 
   return (
     <div className="bg-white">
+      {/* 작성 진입 — 인증 치료사만 노출 */}
+      {canWrite && (
+        <div className="flex justify-end px-4 pt-3">
+          <button
+            type="button"
+            onClick={() => navigate('/job-posts/new')}
+            className="flex items-center gap-1 rounded-lg bg-gray-900 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-black"
+          >
+            <Plus size={14} />
+            구인공고 작성
+          </button>
+        </div>
+      )}
+
       {/* 필터 */}
       <div className="p-4 border-b border-gray-200 space-y-3">
         <FilterChips value={therapyArea} onChange={setTherapyArea} />

--- a/frontend/src/pages/jobpost/JobPostCreatePage.tsx
+++ b/frontend/src/pages/jobpost/JobPostCreatePage.tsx
@@ -1,21 +1,28 @@
-import { useNavigate } from 'react-router-dom';
+import { Navigate, useNavigate } from 'react-router-dom';
 import NarrowPage from '../../components/common/NarrowPage';
 import PageHeader from '../../components/common/PageHeader';
 import JobPostForm from '../../components/jobpost/JobPostForm';
 import { useJobPostMutations } from '../../hooks/useJobPostMutations';
+import { useAuthStore } from '../../stores/useAuthStore';
 import type { JobPostCreatePayload } from '../../types/jobPost';
 
-// Phase 2 구인공고 작성 페이지. 숨긴 라우트(/job-posts/new) — 진입 버튼은 아직 노출 안 함(스테이징 검증용).
-// ADMIN 전용 작성 게이트는 보류(2026-07-03 결정): 이용자 소수라 우선순위 낮음.
+// Phase 2 구인공고 작성 페이지. /job-posts/new.
+// 작성 권한 = 인증 치료사(THERAPIST/ADMIN)만 — 버튼 숨김 + 이 라우트 가드 이중 방어
+// (USER가 URL 직접 진입해도 리다이렉트). 실제 권한 최종 판정은 BE POST가 소유(MSW는 정책 시뮬).
 export default function JobPostCreatePage() {
   const navigate = useNavigate();
+  const user = useAuthStore((s) => s.user);
   const { create } = useJobPostMutations();
+  const canWrite = user?.role === 'THERAPIST' || user?.role === 'ADMIN';
 
   // 캐시 무효화는 create mutation의 onSuccess가 담당(useJobPostMutations). 여기선 상세로 이동만.
   const handleSubmit = async (payload: JobPostCreatePayload) => {
     const created = await create.mutateAsync(payload);
     navigate(`/job-posts/${created.id}`, { state: { from: '/posts?tab=jobs' } });
   };
+
+  // 인증 치료사 아니면 구인 탭으로 돌려보냄(비로그인은 AuthRoute가 이미 로그인으로 보냄).
+  if (!canWrite) return <Navigate to="/posts?tab=jobs" replace />;
 
   return (
     <NarrowPage>


### PR DESCRIPTION
구인공고 작성 진입을 **인증 치료사(THERAPIST/ADMIN)**에게 노출. (2026-07-06 결정: 인증 치료사 자유 작성)

## 변경
- **JobPostFeed**: 구인 탭 상단에 "구인공고 작성" 버튼 — `canWrite`(role THERAPIST/ADMIN)일 때만 렌더
- **JobPostCreatePage**: 라우트 가드 — 비인증 USER가 `/job-posts/new` URL 직접 진입 시 구인 탭으로 리다이렉트(버튼 숨김 + 가드 이중 방어)

## 게이트 기준
`user.role === 'THERAPIST' || 'ADMIN'` — `ProfilePage:157`의 isVerified 컨벤션 재사용. FE는 UX 게이트, 최종 권한 판정은 BE POST 소유(MSW는 정책 시뮬).

## 검증
tsc 0 / eslint 0 / build 0