### PR TITLE
feat: 구인공고 작성 버튼을 FAB로 전환 (Phase 2)

### DIFF
--- a/frontend/src/components/jobpost/JobPostFeed.tsx
+++ b/frontend/src/components/jobpost/JobPostFeed.tsx
@@ -49,20 +49,6 @@ export default function JobPostFeed() {
 
   return (
     <div className="bg-white">
-      {/* 작성 진입 — 인증 치료사만 노출 */}
-      {canWrite && (
-        <div className="flex justify-end px-4 pt-3">
-          <button
-            type="button"
-            onClick={() => navigate('/job-posts/new')}
-            className="flex items-center gap-1 rounded-lg bg-gray-900 px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-black"
-          >
-            <Plus size={14} />
-            구인공고 작성
-          </button>
-        </div>
-      )}
-
       {/* 필터 */}
       <div className="p-4 border-b border-gray-200 space-y-3">
         <FilterChips value={therapyArea} onChange={setTherapyArea} />
@@ -136,6 +122,19 @@ export default function JobPostFeed() {
       )}
 
       <div ref={sentinelRef} aria-hidden className="h-1" />
+
+      {/* 작성 FAB — 인증 치료사만. fixed라 피드 위에 떠 있는 맥락 작성 버튼.
+          모바일=BottomNav(fixed bottom-0) 위로 bottom-20, 데스크탑=콘텐츠 우측(Layout md:mx-20에 맞춰 md:right-24). */}
+      {canWrite && (
+        <button
+          type="button"
+          onClick={() => navigate('/job-posts/new')}
+          aria-label="구인공고 작성"
+          className="fixed bottom-20 right-5 z-30 flex h-14 w-14 items-center justify-center rounded-full bg-gray-900 text-white shadow-lg transition-transform hover:bg-black active:scale-95 md:bottom-8 md:right-24"
+        >
+          <Plus size={24} />
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/jobpost/JobPostFeed.tsx
+++ b/frontend/src/components/jobpost/JobPostFeed.tsx
@@ -123,16 +123,17 @@ export default function JobPostFeed() {
 
       <div ref={sentinelRef} aria-hidden className="h-1" />
 
-      {/* 작성 FAB — 인증 치료사만. fixed라 피드 위에 떠 있는 맥락 작성 버튼.
-          모바일=BottomNav(fixed bottom-0) 위로 bottom-20, 데스크탑=콘텐츠 우측(Layout md:mx-20에 맞춰 md:right-24). */}
+      {/* 작성 확장형 FAB — 인증 치료사만. 알약 모양 + 텍스트 라벨로 정체 명확(벌거벗은 '+' 회피).
+          fixed라 피드 위에 떠 있음. 모바일=BottomNav(fixed bottom-0) 위로 bottom-20,
+          데스크탑=콘텐츠 우측(Layout md:mx-20에 맞춰 md:right-24). */}
       {canWrite && (
         <button
           type="button"
           onClick={() => navigate('/job-posts/new')}
-          aria-label="구인공고 작성"
-          className="fixed bottom-20 right-5 z-30 flex h-14 w-14 items-center justify-center rounded-full bg-gray-900 text-white shadow-lg transition-transform hover:bg-black active:scale-95 md:bottom-8 md:right-24"
+          className="fixed bottom-20 right-5 z-30 flex items-center gap-1.5 rounded-full bg-gray-900 py-3 pl-4 pr-5 text-sm font-semibold text-white shadow-lg transition-transform hover:bg-black active:scale-95 md:bottom-8 md:right-24"
         >
-          <Plus size={24} />
+          <Plus size={18} />
+          구인공고 작성
         </button>
       )}
     </div>


### PR DESCRIPTION
구인공고 작성 진입을 필터 위 인라인 버튼(따로 노는 느낌) → **우측 하단 플로팅 버튼(FAB)**으로 전환. 사용자 디자인 선택(2026-07-06).

## 변경
- `JobPostFeed`: 상단 인라인 버튼 제거 → `fixed` FAB(+ 아이콘, 원형)
- 위치: 모바일=BottomNav 위(`bottom-20`), 데스크탑=콘텐츠 우측(`md:right-24`, Layout `md:mx-20` 정렬)
- 인증 치료사(`canWrite`)만 노출 동일

## 검증
tsc 0 / eslint 0 / build 0

## 참고
위치 오프셋(bottom-20/md:right-24)은 실측 미세조정 여지 있음 — 로컬 확인 후 조정 가능