### PR TITLE
feat: 구인공고 작성 권한을 로그인 전체 유저로 확대

### DIFF
--- a/frontend/src/components/jobpost/JobPostFeed.tsx
+++ b/frontend/src/components/jobpost/JobPostFeed.tsx
@@ -14,9 +14,10 @@ import type { EmploymentType, JobRegion } from '../../types/jobPost';
 export default function JobPostFeed() {
   const navigate = useNavigate();
   const user = useAuthStore((s) => s.user);
-  // 작성 진입은 인증 치료사(THERAPIST/ADMIN)만 — ProfilePage:157의 isVerified 컨벤션 재사용.
-  // 일반 USER/비로그인은 버튼 미노출. (2026-07-06 결정: 인증 치료사 자유 작성)
-  const canWrite = user?.role === 'THERAPIST' || user?.role === 'ADMIN';
+  // 작성 진입은 로그인한 모든 유저(USER/THERAPIST/ADMIN). 비로그인만 미노출.
+  // (2026-07-06 결정 변경: 인증 치료사 한정 → 전체 유저 허용)
+  const canWrite =
+    user?.role === 'USER' || user?.role === 'THERAPIST' || user?.role === 'ADMIN';
 
   const [therapyArea, setTherapyArea] = useState<TherapyArea | ''>('');
   const [region, setRegion] = useState<JobRegion | ''>('');

--- a/frontend/src/pages/jobpost/JobPostCreatePage.tsx
+++ b/frontend/src/pages/jobpost/JobPostCreatePage.tsx
@@ -7,13 +7,15 @@ import { useAuthStore } from '../../stores/useAuthStore';
 import type { JobPostCreatePayload } from '../../types/jobPost';
 
 // Phase 2 구인공고 작성 페이지. /job-posts/new.
-// 작성 권한 = 인증 치료사(THERAPIST/ADMIN)만 — 버튼 숨김 + 이 라우트 가드 이중 방어
-// (USER가 URL 직접 진입해도 리다이렉트). 실제 권한 최종 판정은 BE POST가 소유(MSW는 정책 시뮬).
+// 작성 권한 = 로그인한 모든 유저(USER/THERAPIST/ADMIN) — 버튼 노출(JobPostFeed) + 이 라우트 가드 이중.
+// 비로그인만 차단(AuthRoute). 실제 권한 최종 판정은 BE POST가 소유(MSW는 정책 시뮬).
 export default function JobPostCreatePage() {
   const navigate = useNavigate();
   const user = useAuthStore((s) => s.user);
   const { create } = useJobPostMutations();
-  const canWrite = user?.role === 'THERAPIST' || user?.role === 'ADMIN';
+  // 작성 권한 = 로그인한 모든 유저(USER/THERAPIST/ADMIN). 비로그인만 차단(AuthRoute가 이미 로그인으로 보냄).
+  const canWrite =
+    user?.role === 'USER' || user?.role === 'THERAPIST' || user?.role === 'ADMIN';
 
   // 캐시 무효화는 create mutation의 onSuccess가 담당(useJobPostMutations). 여기선 상세로 이동만.
   const handleSubmit = async (payload: JobPostCreatePayload) => {


### PR DESCRIPTION
작성 버튼/권한을 인증 치료사(THERAPIST/ADMIN)만 → **USER 포함 로그인 전체 유저**로 확대. FAB 노출 게이트 + 라우트 가드 양쪽 canWrite 갱신. tsc/build 0.